### PR TITLE
agents: fix OTLPAgent race conditions on cleanup

### DIFF
--- a/agents/otlp/src/otlp_agent.h
+++ b/agents/otlp/src/otlp_agent.h
@@ -112,8 +112,6 @@ class OTLPAgent {
   uv_cond_t start_cond_;
   uv_mutex_t start_lock_;
 
-  nsuv::ns_rwlock exit_lock_;
-
   bool hooks_init_;
 
   nsuv::ns_async env_msg_;


### PR DESCRIPTION
Move the `exit_lock_` out of the class and make it static so we can use it even if the agent has been deleted.
Also, make sure we use the `exit_lock_` in `OTLPAgent::config_msg_cb_`.

Fixes: https://github.com/nodesource/nsolid/issues/29
