### PR TITLE
agents: fix crash in StatsDAgent

### DIFF
--- a/agents/statsd/src/statsd_agent.cc
+++ b/agents/statsd/src/statsd_agent.cc
@@ -264,9 +264,13 @@ void StatsDUdp::write_cb_(nsuv::ns_udp_send* req, int status, StatsDUdp* udp) {
     struct sockaddr_storage ss;
     struct sockaddr* addr = reinterpret_cast<struct sockaddr*>(&ss);
     int len = sizeof(ss);
-    ASSERT_EQ(0, uv_udp_getpeername(req->handle(), addr, &len));
-    Debug("Error '%s' sending data to: %s.\n",
-          uv_err_name(status), addr_to_string(addr).c_str());
+    int r = uv_udp_getpeername(req->handle(), addr, &len);
+    if (r == 0) {
+      Debug("Error '%s' sending data to: %s.\n",
+            uv_err_name(status), addr_to_string(addr).c_str());
+    } else {
+      Debug("Error '%s' sending data to\n", uv_err_name(status));
+    }
   }
 
   udp_req_data_tup* req_data = req->get_data<udp_req_data_tup>();


### PR DESCRIPTION
With some specific udp send errors, it's not possible to retrieve the peername. Handle this case to avoid crashes.

Fixes: https://github.com/nodesource/nsolid/issues/31

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
