### PR TITLE
src: NODE_RELEASE should be node

### DIFF
--- a/src/node_version.h
+++ b/src/node_version.h
@@ -44,7 +44,7 @@
 #endif
 
 #ifndef NODE_RELEASE
-#define NODE_RELEASE "nsolid"
+#define NODE_RELEASE "node"
 #endif
 
 #ifndef NODE_TAG

--- a/test/fixtures/errors/promise_unhandled_warn_with_error.snapshot
+++ b/test/fixtures/errors/promise_unhandled_warn_with_error.snapshot
@@ -1,4 +1,4 @@
-(nsolid:*) UnhandledPromiseRejectionWarning: Error: alas
+(node:*) UnhandledPromiseRejectionWarning: Error: alas
     at *
     at *
     at *
@@ -7,4 +7,4 @@
     at *
     at *
 (Use `nsolid --trace-warnings ...` to show where the warning was created)
-(nsolid:*) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). To terminate the node process on unhandled promise rejection, use the CLI flag `--unhandled-rejections=strict` (see https:*nodejs.org*api*cli.html#cli_unhandled_rejections_mode). (rejection id: 1)
+(node:*) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). To terminate the node process on unhandled promise rejection, use the CLI flag `--unhandled-rejections=strict` (see https:*nodejs.org*api*cli.html#cli_unhandled_rejections_mode). (rejection id: 1)

--- a/test/fixtures/errors/unhandled_promise_trace_warnings.snapshot
+++ b/test/fixtures/errors/unhandled_promise_trace_warnings.snapshot
@@ -1,4 +1,4 @@
-(nsolid:*) UnhandledPromiseRejectionWarning: Error: This was rejected
+(node:*) UnhandledPromiseRejectionWarning: Error: This was rejected
     at *
     at *
     at *
@@ -9,7 +9,7 @@
     at *
     at *
     at *
-(nsolid:*) Error: This was rejected
+(node:*) Error: This was rejected
     at *
     at *
     at *
@@ -17,7 +17,7 @@
     at *
     at *
     at *
-(nsolid:*) PromiseRejectionHandledWarning: Promise rejection was handled asynchronously (rejection id: 1)
+(node:*) PromiseRejectionHandledWarning: Promise rejection was handled asynchronously (rejection id: 1)
     at *
     at *
     at Promise.then (<anonymous>)

--- a/test/message/v8_warning.out
+++ b/test/message/v8_warning.out
@@ -1,2 +1,2 @@
-(nsolid:*) V8: *v8_warning.js:* Invalid asm.js: Invalid return type
+(node:*) V8: *v8_warning.js:* Invalid asm.js: Invalid return type
 (Use `* --trace-warnings ...` to show where the warning was created)

--- a/test/parallel/test-process-redirect-warnings-env.js
+++ b/test/parallel/test-process-redirect-warnings-env.js
@@ -20,6 +20,6 @@ const warnpath = tmpdir.resolve('warnings.txt');
 fork(warnmod, { env: { ...process.env, NODE_REDIRECT_WARNINGS: warnpath } })
   .on('exit', common.mustCall(() => {
     fs.readFile(warnpath, 'utf8', common.mustSucceed((data) => {
-      assert.match(data, /\(nsolid:\d+\) Warning: a bad practice warning/);
+      assert.match(data, /\(node:\d+\) Warning: a bad practice warning/);
     }));
   }));

--- a/test/parallel/test-process-redirect-warnings.js
+++ b/test/parallel/test-process-redirect-warnings.js
@@ -20,6 +20,6 @@ const warnpath = tmpdir.resolve('warnings.txt');
 fork(warnmod, { execArgv: [`--redirect-warnings=${warnpath}`] })
   .on('exit', common.mustCall(() => {
     fs.readFile(warnpath, 'utf8', common.mustSucceed((data) => {
-      assert.match(data, /\(nsolid:\d+\) Warning: a bad practice warning/);
+      assert.match(data, /\(node:\d+\) Warning: a bad practice warning/);
     }));
   }));

--- a/test/parallel/test-process-release.js
+++ b/test/parallel/test-process-release.js
@@ -5,7 +5,7 @@ require('../common');
 const assert = require('assert');
 const versionParts = process.versions.node.split('.');
 
-assert.strictEqual(process.release.name, 'nsolid');
+assert.strictEqual(process.release.name, 'node');
 
 // It's expected that future LTS release lines will have additional
 // branches in here

--- a/test/pseudo-tty/test-tty-color-support-warning-2.out
+++ b/test/pseudo-tty/test-tty-color-support-warning-2.out
@@ -1,3 +1,3 @@
 
-(nsolid:*) Warning: The 'NODE_DISABLE_COLORS' env is ignored due to the 'FORCE_COLOR' env being set.
+(node:*) Warning: The 'NODE_DISABLE_COLORS' env is ignored due to the 'FORCE_COLOR' env being set.
 (Use `* --trace-warnings ...` to show where the warning was created)

--- a/test/pseudo-tty/test-tty-color-support-warning.out
+++ b/test/pseudo-tty/test-tty-color-support-warning.out
@@ -1,3 +1,3 @@
 
-(nsolid:*) Warning: The 'NODE_DISABLE_COLORS' and 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+(node:*) Warning: The 'NODE_DISABLE_COLORS' and 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
 (Use `* --trace-warnings ...` to show where the warning was created)

--- a/test/pseudo-tty/test-tty-color-support.out
+++ b/test/pseudo-tty/test-tty-color-support.out
@@ -1,2 +1,2 @@
-(nsolid:*) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
+(node:*) Warning: The 'NO_COLOR' env is ignored due to the 'FORCE_COLOR' env being set.
 (Use `* --trace-warnings ...` to show where the warning was created)


### PR DESCRIPTION
So we remain compatible with Node.js.

Example of code that was broken before this change:
https://github.com/google/dart_cli_pkg/blob/main/lib/src/js/js.dart#L47