### PR TITLE
src: make nsolid::ThreadMetrics safer

### DIFF
--- a/agents/otlp/src/otlp_agent.h
+++ b/agents/otlp/src/otlp_agent.h
@@ -28,10 +28,11 @@ namespace nsolid {
 namespace otlp {
 
 struct JSThreadMetrics {
-  ThreadMetrics metrics_;
+  SharedThreadMetrics metrics_;
   ThreadMetrics::MetricsStor prev_;
-  explicit JSThreadMetrics(SharedEnvInst envinst): metrics_(envinst),
-                                                    prev_() {}
+  explicit JSThreadMetrics(SharedEnvInst envinst)
+    : metrics_(ThreadMetrics::Create(envinst)),
+      prev_() {}
 };
 
 class OTLPAgent {
@@ -73,7 +74,7 @@ class OTLPAgent {
 
   static void metrics_msg_cb_(nsuv::ns_async*, OTLPAgent* agent);
 
-  static void thr_metrics_cb_(ThreadMetrics*, OTLPAgent*);
+  static void thr_metrics_cb_(SharedThreadMetrics, OTLPAgent*);
 
   void do_start();
 
@@ -132,7 +133,7 @@ class OTLPAgent {
   ProcessMetrics::MetricsStor proc_prev_stor_;
   std::map<uint64_t, JSThreadMetrics> env_metrics_map_;
   nsuv::ns_async metrics_msg_;
-  TSQueue<ThreadMetrics*> thr_metrics_msg_q_;
+  TSQueue<ThreadMetrics::MetricsStor> thr_metrics_msg_q_;
   nsuv::ns_timer metrics_timer_;
   std::unique_ptr<MetricsExporter> metrics_exporter_;
 

--- a/agents/statsd/src/statsd_agent.h
+++ b/agents/statsd/src/statsd_agent.h
@@ -204,7 +204,7 @@ class StatsDAgent {
 
   static void send_stats_msg_cb_(nsuv::ns_async*, StatsDAgent*);
 
-  static void env_metrics_cb_(ThreadMetrics*, StatsDAgent*);
+  static void env_metrics_cb_(SharedThreadMetrics, StatsDAgent*);
 
   static void status_command_cb_(SharedEnvInst, StatsDAgent*);
 
@@ -258,11 +258,11 @@ class StatsDAgent {
   nsuv::ns_timer retry_timer_;
 
   // For the Metrics API
-  std::map<uint64_t, ThreadMetrics> env_metrics_map_;
+  std::map<uint64_t, SharedThreadMetrics> env_metrics_map_;
   ProcessMetrics proc_metrics_;
   uint64_t metrics_period_;
   nsuv::ns_async metrics_msg_;
-  TSQueue<ThreadMetrics*> metrics_msg_q_;
+  TSQueue<ThreadMetrics::MetricsStor> metrics_msg_q_;
   nsuv::ns_timer metrics_timer_;
 
   // For the Configuration API

--- a/agents/zmq/src/zmq_agent.h
+++ b/agents/zmq/src/zmq_agent.h
@@ -356,10 +356,12 @@ class ZmqAgent {
   };
 
   struct EnvMetricsStor {
-    ThreadMetrics t_metrics;
+    SharedThreadMetrics t_metrics;
     bool fetching;
-    explicit EnvMetricsStor(SharedEnvInst envinst, bool f): t_metrics(envinst),
-                                                             fetching(f) {}
+    NSOLID_DELETE_DEFAULT_CONSTRUCTORS(EnvMetricsStor)
+    explicit EnvMetricsStor(SharedEnvInst envinst, bool f)
+      : t_metrics(ThreadMetrics::Create(envinst)),
+        fetching(f) {}
   };
 
   struct ZmqCommandError {
@@ -478,7 +480,7 @@ class ZmqAgent {
 
   static void update_state_msg_cb(nsuv::ns_async*, ZmqAgent*);
 
-  static void env_metrics_cb(ThreadMetrics*, ZmqAgent*);
+  static void env_metrics_cb(SharedThreadMetrics, ZmqAgent*);
 
   static void status_command_cb(SharedEnvInst, ZmqAgent*);
 
@@ -555,7 +557,7 @@ class ZmqAgent {
                                    const std::pair<bool, std::string>&,
                                    const std::pair<bool, std::string>&);
 
-  void got_env_metrics(ThreadMetrics* t_metrics);
+  void got_env_metrics(const ThreadMetrics::MetricsStor& stor);
 
   void got_heap_snapshot(int status,
                          const std::string& snaphost,
@@ -657,7 +659,7 @@ class ZmqAgent {
   ProcessMetrics proc_metrics_;
   uint64_t metrics_period_;
   nsuv::ns_async metrics_msg_;
-  TSQueue<ThreadMetrics*> metrics_msg_q_;
+  TSQueue<ThreadMetrics::MetricsStor> metrics_msg_q_;
   nsuv::ns_timer metrics_timer_;
   std::string cached_metrics_;
   std::set<std::string> pending_metrics_reqs_;

--- a/test/addons/nsolid-env-metrics/binding.cc
+++ b/test/addons/nsolid-env-metrics/binding.cc
@@ -8,10 +8,16 @@
 std::atomic<int> cb_cntr = { 0 };
 
 using node::nsolid::ThreadMetrics;
+using node::nsolid::SharedThreadMetrics;
 
-static void got_env_metrics(ThreadMetrics* tm) {
+struct Metrics {
+  SharedThreadMetrics tm;
+};
+
+static void got_env_metrics(SharedThreadMetrics tm_sp, Metrics* m) {
+  assert(tm_sp == m->tm);
   cb_cntr++;
-  delete tm;
+  delete m;
 }
 
 static void GetMetrics(const v8::FunctionCallbackInfo<v8::Value>& args) {
@@ -27,13 +33,17 @@ static void GetMetrics(const v8::FunctionCallbackInfo<v8::Value>& args) {
     assert(envinst != nullptr);
   }
 
-  auto* tm = new node::nsolid::ThreadMetrics(envinst);
+  Metrics* metrics = new Metrics{ThreadMetrics::Create(envinst)};
 
-  int er = tm->Update(got_env_metrics);
-  if (er)
-    delete tm;
+  int er = metrics->tm->Update(got_env_metrics, metrics);
+  args.GetReturnValue().Set(er);
+}
+
+static void GetCbCntr(const v8::FunctionCallbackInfo<v8::Value>& args) {
+  args.GetReturnValue().Set(cb_cntr);
 }
 
 NODE_MODULE_INIT(/* exports, module, context */) {
+  NODE_SET_METHOD(exports, "getCbCntr", GetCbCntr);
   NODE_SET_METHOD(exports, "getMetrics", GetMetrics);
 }

--- a/test/addons/nsolid-env-metrics/nsolid-env-metrics.js
+++ b/test/addons/nsolid-env-metrics/nsolid-env-metrics.js
@@ -21,6 +21,10 @@ if (!isMainThread) {
   return;
 }
 
+process.on('beforeExit', mustCall(() => {
+  assert.strictEqual(binding.getCbCntr(), 11);
+}));
+
 for (let i = 0; i < 10; i++) {
   const worker = new Worker(__filename, { argv: [process.pid] });
   worker.on('exit', (code) => {

--- a/test/addons/nsolid-metrics/binding.cc
+++ b/test/addons/nsolid-metrics/binding.cc
@@ -5,7 +5,9 @@
 #include <assert.h>
 #include <atomic>
 
+using node::nsolid::GetEnvInst;
 using node::nsolid::ProcessMetrics;
+using node::nsolid::SharedThreadMetrics;
 using node::nsolid::ThreadMetrics;
 
 using v8::FunctionCallbackInfo;
@@ -14,19 +16,49 @@ using v8::Uint32;
 using v8::Value;
 
 std::atomic<int> cb_cntr = { 0 };
+std::atomic<int> cb_cntr_lambda = { 0 };
+std::atomic<int> cb_cntr_gone = { 0 };
 
-static void metrics_cb(ThreadMetrics* tm, void*, ThreadMetrics*) {
+struct Metrics {
+  SharedThreadMetrics tm;
+};
+
+static void metrics_cb(SharedThreadMetrics tm, void*, Metrics* m) {
+  assert(tm == m->tm);
   cb_cntr++;
-  delete tm;
+  delete m;
+}
+
+static void metrics_cb_gone(SharedThreadMetrics tm, void*, ThreadMetrics*) {
+  cb_cntr_gone++;
 }
 
 static void GetEnvMetrics(const FunctionCallbackInfo<Value>& args) {
   assert(args[0]->IsNumber());
-
   uint64_t thread_id = args[0].As<Uint32>()->Value();
-  auto* tm = new ThreadMetrics(node::nsolid::GetEnvInst(thread_id));
+  Metrics* metrics = new Metrics{ThreadMetrics::Create(GetEnvInst(thread_id))};
+  args.GetReturnValue().Set(metrics->tm->Update(metrics_cb, nullptr, metrics));
+}
 
-  args.GetReturnValue().Set(tm->Update(metrics_cb, nullptr, tm));
+static void GetEnvMetricsGone(const FunctionCallbackInfo<Value>& args) {
+  assert(args[0]->IsNumber());
+  uint64_t thread_id = args[0].As<Uint32>()->Value();
+  SharedThreadMetrics tm = ThreadMetrics::Create(GetEnvInst(thread_id));
+  // The cb should never be called as SharedThreadMetrics is destroyed right
+  // after leaving the current scope.
+  args.GetReturnValue().Set(tm->Update(metrics_cb_gone, nullptr, tm.get()));
+}
+
+static void GetEnvMetricsLambda(const FunctionCallbackInfo<Value>& args) {
+  assert(args[0]->IsNumber());
+  uint64_t thread_id = args[0].As<Uint32>()->Value();
+  Metrics* metrics = new Metrics{ThreadMetrics::Create(GetEnvInst(thread_id))};
+  int ret = metrics->tm->Update([](SharedThreadMetrics tm, void*, Metrics* m) {
+    assert(tm == m->tm);
+    cb_cntr_lambda++;
+    delete m;
+  }, nullptr, metrics);
+  args.GetReturnValue().Set(ret);
 }
 
 static void GetProcMetrics(const FunctionCallbackInfo<Value>& args) {
@@ -46,8 +78,20 @@ static void GetCbCntr(const FunctionCallbackInfo<Value>& args) {
   args.GetReturnValue().Set(cb_cntr);
 }
 
+static void GetCbCntrGone(const FunctionCallbackInfo<Value>& args) {
+  args.GetReturnValue().Set(cb_cntr_gone);
+}
+
+static void GetCbCntrLambda(const FunctionCallbackInfo<Value>& args) {
+  args.GetReturnValue().Set(cb_cntr_lambda);
+}
+
 NODE_MODULE_INIT(/* exports, module, context */) {
   NODE_SET_METHOD(exports, "getCbCntr", GetCbCntr);
+  NODE_SET_METHOD(exports, "getCbCntrGone", GetCbCntrGone);
+  NODE_SET_METHOD(exports, "getCbCntrLambda", GetCbCntrLambda);
   NODE_SET_METHOD(exports, "getEnvMetrics", GetEnvMetrics);
+  NODE_SET_METHOD(exports, "getEnvMetricsGone", GetEnvMetricsGone);
+  NODE_SET_METHOD(exports, "getEnvMetricsLambda", GetEnvMetricsLambda);
   NODE_SET_METHOD(exports, "getProcMetrics", GetProcMetrics);
 }

--- a/test/addons/nsolid-metrics/nsolid-metrics.js
+++ b/test/addons/nsolid-metrics/nsolid-metrics.js
@@ -25,6 +25,8 @@ if (!isMainThread) {
 
 process.on('beforeExit', mustCall(() => {
   assert.strictEqual(binding.getCbCntr(), wkr_count);
+  assert.strictEqual(binding.getCbCntrGone(), 0);
+  assert.strictEqual(binding.getCbCntrLambda(), wkr_count);
 }));
 
 const metrics = binding.getProcMetrics();
@@ -37,6 +39,8 @@ for (let i = 0; i < wkr_count; i++) {
   }));
   worker.on('online', mustCall(() => {
     assert.strictEqual(binding.getEnvMetrics(worker.threadId), 0);
+    assert.strictEqual(binding.getEnvMetricsLambda(worker.threadId), 0);
+    assert.strictEqual(binding.getEnvMetricsGone(worker.threadId), 0);
     worker.postMessage('exit');
   }));
 }


### PR DESCRIPTION
The current ThreadMetrics API is not easy to use safely because the `ThreadMetrics` instance needs to be alive while there is a pending `Update()` callback to be called. Change the API to use shared_ptr, as we define a new type `SharedThreadMetrics` as
`std::shared_ptr<ThreadMetrics>`. 
This is a breaking change but considering previous API was completely
unsafe and apparently there're still no consumers I think is a good
change.

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
