### PR TITLE
agents: fix exit message format

### DIFF
--- a/agents/zmq/src/zmq_agent.cc
+++ b/agents/zmq/src/zmq_agent.cc
@@ -128,7 +128,7 @@ const char MSG_6[] = "{"
   ",\"command\":\"exit\""
   ",\"exit_code\":%d"
   ",\"version\":%d"
-  ",\"error\":{\"message\":\"%s\",\"stack\":\"%s\",\"code\":%d}"
+  ",\"error\":{\"message\":%s,\"stack\":%s,\"code\":%d}"
 "}";
 
 const char MSG_7[] = "{"
@@ -144,7 +144,7 @@ const char MSG_8[] = "{"
   ",\"command\":\"exit\""
   ",\"exit_code\":%d"
   ",\"version\":%d"
-  ",\"error\":{\"message\":\"%s\",\"stack\":\"%s\",\"code\":%d}"
+  ",\"error\":{\"message\":%s,\"stack\":%s,\"code\":%d}"
   ",\"profile\":%s"
 "}";
 
@@ -1843,6 +1843,9 @@ void ZmqAgent::send_exit() {
                    last_main_profile_.c_str());
     }
   } else {
+    // Use nlohmann::json to properly escape the error message and stack.
+    nlohmann::json jmsg(std::get<0>(*error));
+    nlohmann::json jstack(std::get<1>(*error));
     if (last_main_profile_.empty()) {
       r = snprintf(msg_buf_,
                    msg_size_,
@@ -1850,8 +1853,8 @@ void ZmqAgent::send_exit() {
                    agent_id_.c_str(),
                    exit_code,
                    version_,
-                   std::get<0>(*error).c_str(),
-                   std::get<1>(*error).c_str(),
+                   jmsg.dump().c_str(),
+                   jstack.dump().c_str(),
                    500);
     } else {
       r = snprintf(msg_buf_,
@@ -1860,8 +1863,8 @@ void ZmqAgent::send_exit() {
                    agent_id_.c_str(),
                    exit_code,
                    version_,
-                   std::get<0>(*error).c_str(),
-                   std::get<1>(*error).c_str(),
+                   jmsg.dump().c_str(),
+                   jstack.dump().c_str(),
                    500,
                    last_main_profile_.c_str());
     }


### PR DESCRIPTION
The `message` and `stack` fields should be properly escaped.

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
