### PR TITLE
test: initial batch of zmq agent tests

### DIFF
--- a/agents/zmq/src/binding.cc
+++ b/agents/zmq/src/binding.cc
@@ -10,6 +10,7 @@ using v8::Isolate;
 using v8::JSON;
 using v8::Local;
 using v8::NewStringType;
+using v8::Number;
 using v8::Object;
 using v8::String;
 using v8::Value;
@@ -60,7 +61,7 @@ static void StartCPUProfile(const FunctionCallbackInfo<Value>& args) {
   Isolate* isolate = args.GetIsolate();
   Local<Context> context = isolate->GetCurrentContext();
   uint64_t thread_id = ThreadId(context);
-  int timeout = args[0]->ToInt32(context).ToLocalChecked()->Value();
+  uint64_t timeout = args[0].As<Number>()->Value();
   json message = {
     { "args", {
       { "metadata", {

--- a/src/nsolid/nsolid_api.cc
+++ b/src/nsolid/nsolid_api.cc
@@ -323,7 +323,9 @@ std::string EnvInst::GetOnBlockedBody() {
   uint64_t exit_time = metrics.loop_count == 0 ?
     env()->time_origin() : provider_times().second;
 
-  body_string += "\"blocked_for\":";
+  body_string += "\"threadId\":";
+  body_string += std::to_string(thread_id_);
+  body_string += ",\"blocked_for\":";
   body_string += std::to_string((uv_hrtime() - exit_time) / MICROS_PER_SEC);
   body_string += ",\"loop_id\":";
   body_string += std::to_string(metrics.loop_count);

--- a/test/.eslintrc.yaml
+++ b/test/.eslintrc.yaml
@@ -76,6 +76,8 @@ globals:
 
 overrides:
   - files:
+      - agents/*.js
+      - agents/*.mjs
       - es-module/*.js
       - es-module/*.mjs
       - parallel/*.js

--- a/test/agents/test-zmq-basic.mjs
+++ b/test/agents/test-zmq-basic.mjs
@@ -1,0 +1,105 @@
+import { mustCall, mustSucceed } from '../common/index.mjs';
+import assert from 'node:assert';
+import {
+  checkExitData,
+  TestPlayground,
+} from '../common/nsolid-zmq-agent/index.js';
+
+const SIGTERM = 15;
+
+const tests = [];
+
+tests.push({
+  name: 'should work if agent is killed with signal',
+  test: async (playground) => {
+    return new Promise((resolve) => {
+      playground.bootstrap(mustSucceed(async (agentId) => {
+        const exit = await playground.client.kill();
+        assert.ok(exit);
+        assert.strictEqual(exit.code, null);
+        assert.strictEqual(exit.signal, 'SIGTERM');
+        resolve();
+      }), (eventType, agentId, data) => {
+        assert.strictEqual(eventType, 'agent-exit');
+        checkExitData(data, { exit_code: SIGTERM, error: null });
+      });
+    });
+  },
+});
+
+tests.push({
+  name: 'should work if agent exits gracefully without error',
+  test: async (playground) => {
+    return new Promise((resolve) => {
+      playground.bootstrap(mustSucceed(async (agentId) => {
+        const exit = await playground.client.shutdown(0);
+        assert.ok(exit);
+        assert.strictEqual(exit.code, 0);
+        assert.strictEqual(exit.signal, null);
+        resolve();
+      }), mustCall((eventType, agentId, data) => {
+        assert.strictEqual(eventType, 'agent-exit');
+        checkExitData(data, { exit_code: 0, error: null });
+      }));
+    });
+  },
+});
+
+tests.push({
+  name: 'should work if agent exits gracefully with error code',
+  test: async (playground) => {
+    return new Promise((resolve) => {
+      playground.bootstrap(mustSucceed(async (agentId) => {
+        const exit = await playground.client.shutdown(1);
+        assert.ok(exit);
+        assert.strictEqual(exit.code, 1);
+        assert.strictEqual(exit.signal, null);
+        resolve();
+      }), mustCall((eventType, agentId, data) => {
+        assert.strictEqual(eventType, 'agent-exit');
+        checkExitData(data, { exit_code: 1, error: null });
+      }));
+    });
+  },
+});
+
+tests.push({
+  name: 'should work if agent exits with exception',
+  test: async (playground) => {
+    return new Promise((resolve) => {
+      playground.bootstrap(mustSucceed(async (agentId) => {
+        const exit = await playground.client.exception('msg');
+        assert.ok(exit);
+        assert.strictEqual(exit.code, 1);
+        assert.strictEqual(exit.signal, null);
+        resolve();
+      }), mustCall((eventType, agentId, data) => {
+        assert.strictEqual(eventType, 'agent-exit');
+        assert.strictEqual(data.exit_code, 1);
+        assert.strictEqual(data.error.code, 500);
+        assert.strictEqual(data.error.message, 'Uncaught Error: error');
+        assert.ok(data.error.stack);
+      }));
+    });
+  },
+});
+
+const config = {
+  commandBindAddr: 'tcp://*:9001',
+  dataBindAddr: 'tcp://*:9002',
+  bulkBindAddr: 'tcp://*:9003',
+  HWM: 0,
+  bulkHWM: 0,
+  commandTimeoutMilliseconds: 5000,
+};
+
+const playground = new TestPlayground(config);
+await playground.startServer();
+
+for (const { name, test } of tests) {
+  console.log(`basic boostrap and exit ${name}`);
+  await test(playground);
+  await playground.stopClient();
+}
+
+playground.stopServer();

--- a/test/agents/test-zmq-blocked-loop.mjs
+++ b/test/agents/test-zmq-blocked-loop.mjs
@@ -1,0 +1,227 @@
+// Flags: --expose-internals
+import { mustCall, mustSucceed } from '../common/index.mjs';
+import assert from 'node:assert';
+import { threadId } from 'node:worker_threads';
+import validators from 'internal/validators';
+import { TestPlayground } from '../common/nsolid-zmq-agent/index.js';
+
+const {
+  validateArray,
+  validateInteger,
+  validateObject,
+  validateString,
+  validateUint32,
+} = validators;
+
+// Data has this format:
+// {
+//   agentId: 'a6349a3418a928009e64672ea6c35400226e035f',
+//   requestId: null,
+//   command: 'loop_blocked',
+//   recorded: { seconds: 1705427872, nanoseconds: 886283288 },
+//   duration: 0,
+//   interval: 3000,
+//   version: 4,
+//   body: {
+//     blocked_for: 134,
+//     loop_id: 2,
+//     callback_cntr: 1,
+//     stack: [
+//       {
+//         is_eval: false,
+//         script_name: '/home/sgimeno/nodesource/nsolid/test/common/nsolid-zmq-agent/client.js',
+//         function_name: null,
+//         line_number: 93,
+//         column: 7
+//       },
+//       {
+//         is_eval: false,
+//         script_name: 'node:events',
+//         function_name: 'emit',
+//         line_number: 518,
+//         column: 28
+//       },
+//       {
+//         is_eval: false,
+//         script_name: 'node:internal/child_process',
+//         function_name: 'emit',
+//         line_number: 951,
+//         column: 14
+//       },
+//       {
+//         is_eval: false,
+//         script_name: 'node:internal/process/task_queues',
+//         function_name: 'processTicksAndRejections',
+//         line_number: 83,
+//         column: 21
+//       }
+//     ]
+//   },
+//   time: 1705427872886,
+//   timeNS: '1705427872886283288'
+// }
+function checkBlockedLoopData(blocked, agentId, threadId) {
+  console.dir(blocked, { depth: null });
+  assert.strictEqual(blocked.requestId, null);
+  assert.strictEqual(blocked.agentId, agentId);
+  assert.strictEqual(blocked.command, 'loop_blocked');
+  // From here check at least that all the fields are present
+  validateObject(blocked.recorded, 'recorded');
+  validateUint32(blocked.recorded.seconds, 'recorded.seconds');
+  validateUint32(blocked.recorded.nanoseconds, 'recorded.nanoseconds');
+  validateUint32(blocked.duration, 'duration');
+  validateUint32(blocked.interval, 'interval');
+  assert.strictEqual(blocked.version, 4);
+  validateObject(blocked.body, 'body');
+  validateInteger(blocked.time, 'time');
+  // also the body fields
+  validateInteger(blocked.body.blocked_for, 'blocked_for');
+  validateInteger(blocked.body.loop_id, 'loop_id');
+  validateInteger(blocked.body.callback_cntr, 'callback_cntr');
+  validateArray(blocked.body.stack, 'stack');
+  for (const frame of blocked.body.stack) {
+    validateObject(frame, 'frame');
+    validateString(frame.script_name, 'script_name');
+    if (frame.function_name !== null) {
+      validateString(frame.function_name, 'function_name');
+    }
+
+    validateInteger(frame.line_number, 'line_number');
+    validateInteger(frame.column, 'column');
+  }
+
+  assert.strictEqual(blocked.body.threadId, threadId);
+}
+
+// Data has this format:
+// {
+//   agentId: '0fc6f773f8854000a1c6717af3e79500836567a4',
+//   requestId: null,
+//   command: 'loop_unblocked',
+//   recorded: { seconds: 1705428376, nanoseconds: 685445475 },
+//   duration: 0,
+//   interval: 3000,
+//   version: 4,
+//   body: { blocked_for: 150, loop_id: 2, callback_cntr: 1 },
+//   time: 1705428376685,
+//   timeNS: '1705428376685445475'
+// }
+function checkUnblockedLoopData(blocked, agentId, threadId, bInfo) {
+  console.dir(blocked, { depth: null });
+  assert.strictEqual(blocked.requestId, null);
+  assert.strictEqual(blocked.agentId, agentId);
+  assert.strictEqual(blocked.command, 'loop_unblocked');
+  // From here check at least that all the fields are present
+  validateObject(blocked.recorded, 'recorded');
+  validateUint32(blocked.recorded.seconds, 'recorded.seconds');
+  validateUint32(blocked.recorded.nanoseconds, 'recorded.nanoseconds');
+  validateUint32(blocked.duration, 'duration');
+  validateUint32(blocked.interval, 'interval');
+  assert.strictEqual(blocked.version, 4);
+  validateObject(blocked.body, 'body');
+  validateInteger(blocked.time, 'time');
+  // also the body fields
+  validateInteger(blocked.body.blocked_for, 'blocked_for');
+  validateInteger(blocked.body.loop_id, 'loop_id');
+  validateInteger(blocked.body.callback_cntr, 'callback_cntr');
+
+}
+
+
+const tests = [];
+
+tests.push({
+  name: 'should work in the main thread',
+  test: async (playground) => {
+    return new Promise((resolve) => {
+      let events = 0;
+      let bInfo = null;
+      const opts = {
+        opts: { env: { NSOLID_BLOCKED_LOOP_THRESHOLD: 100 } }
+      };
+
+      playground.bootstrap(opts, mustSucceed(async (agentId) => {
+        await playground.client.block(threadId, 400);
+      }), mustCall((eventType, agentId, data) => {
+        console.log(`${eventType}, ${agentId}`);
+        switch (++events) {
+          case 1:
+            assert.strictEqual(eventType, 'agent-loop_blocked');
+            checkBlockedLoopData(data, agentId, threadId);
+            bInfo = {
+              blocked_for: data.body.blocked_for,
+              loop_id: data.body.loop_id,
+              callback_cntr: data.body.callback_cntr
+            };
+            break;
+          case 2:
+            assert.strictEqual(eventType, 'agent-loop_unblocked');
+            checkUnblockedLoopData(data, agentId, threadId, bInfo);
+            resolve();
+            break;
+        }
+      }, 2));
+    });
+  }
+});
+
+tests.push({
+  name: 'should work for http transactions on a worker',
+  test: async (playground) => {
+    return new Promise((resolve) => {
+      let wid;
+      let events = 0;
+      let bInfo = null;
+      const opts = {
+        args: [ '-w', 1 ],
+        opts: { env: { NSOLID_BLOCKED_LOOP_THRESHOLD: 100 } }
+      };
+
+      playground.bootstrap(opts, mustSucceed(async (agentId) => {
+        const workers = await playground.client.workers();
+        wid = workers[0];
+        await playground.client.block(wid, 400);
+      }), mustCall((eventType, agentId, data) => {
+        console.log(`${eventType}, ${agentId}`);
+        switch (++events) {
+          case 1:
+            assert.strictEqual(eventType, 'agent-loop_blocked');
+            checkBlockedLoopData(data, agentId, wid);
+            bInfo = {
+              blocked_for: data.body.blocked_for,
+              loop_id: data.body.loop_id,
+              callback_cntr: data.body.callback_cntr
+            };
+            break;
+          case 2:
+            assert.strictEqual(eventType, 'agent-loop_unblocked');
+            checkUnblockedLoopData(data, agentId, wid, bInfo);
+            resolve();
+            break;
+        }
+      }, 2));
+    });
+  }
+});
+
+
+const config = {
+  commandBindAddr: 'tcp://*:9001',
+  dataBindAddr: 'tcp://*:9002',
+  bulkBindAddr: 'tcp://*:9003',
+  HWM: 0,
+  bulkHWM: 0,
+  commandTimeoutMilliseconds: 5000
+};
+
+
+const playground = new TestPlayground(config);
+await playground.startServer();
+
+for (const { name, test } of tests) {
+  console.log(`blocked loop generation ${name}`);
+  await test(playground);
+  await playground.stopClient();
+}
+
+playground.stopServer();

--- a/test/agents/test-zmq-info.mjs
+++ b/test/agents/test-zmq-info.mjs
@@ -1,0 +1,158 @@
+import { mustSucceed } from '../common/index.mjs';
+import assert from 'node:assert';
+import { TestPlayground } from '../common/nsolid-zmq-agent/index.js';
+
+// Data has this format:
+// {
+//   agentId: 'e02f36ca1d154a005c9204ea593c57003a17e0b6',
+//   requestId: '0067b635-967d-4bbe-abd3-eb08f0442d4e',
+//   command: 'info',
+//   recorded: { seconds: 1703092555, nanoseconds: 203389582 },
+//   duration: 0,
+//   interval: 3000,
+//   version: 4,
+//   body: {
+//     app: 'untitled application',
+//     arch: 'x64',
+//     cpuCores: 12,
+//     cpuModel: 'Intel(R) Core(TM) i7-8750H CPU @ 2.20GHz',
+//     execPath: '/home/sgimeno/nodesource/nsolid/out/Release/nsolid',
+//     hostname: 'sgimeno-N8xxEZ',
+//     id: 'e02f36ca1d154a005c9204ea593c57003a17e0b6',
+//     main: '/home/sgimeno/nodesource/nsolid/test/fixtures/nsolid-start.js',
+//     nodeEnv: 'prod',
+//     pid: 457470,
+//     platform: 'linux',
+//     processStart: 1703092555126,
+//     tags: [],
+//     totalMem: 33359147008,
+//     versions: {
+//       acorn: '8.10.0',
+//       ada: '2.7.2',
+//       ares: '1.20.1',
+//       base64: '0.5.0',
+//       brotli: '1.0.9',
+//       cjs_module_lexer: '1.2.2',
+//       cldr: '43.1',
+//       icu: '73.2',
+//       llhttp: '8.1.1',
+//       modules: '115',
+//       napi: '9',
+//       nghttp2: '1.57.0',
+//       nghttp3: '0.7.0',
+//       ngtcp2: '0.8.1',
+//       node: '20.10.0',
+//       nsolid: '5.0.2-pre',
+//       openssl: '3.0.12+quic',
+//       simdutf: '3.2.18',
+//       tz: '2023c',
+//       undici: '5.26.4',
+//       unicode: '15.0',
+//       uv: '1.46.0',
+//       uvwasi: '0.0.19',
+//       v8: '11.3.244.8-node.25',
+//       zlib: '1.2.13.1-motley'
+//     }
+//   },
+//   time: 1703092555203,
+//   timeNS: '1703092555203389582'
+// }
+
+function checkInfoData(info, requestId, agentId, nsolidConfig = {}) {
+  assert.strictEqual(info.requestId, requestId);
+  assert.strictEqual(info.agentId, agentId);
+  assert.strictEqual(info.command, 'info');
+  // From here check at least that all the fields are present
+  assert.ok(info.recorded);
+  assert.ok(info.recorded.seconds);
+  assert.ok(info.recorded.nanoseconds);
+  assert.ok(info.duration != null);
+  assert.ok(info.interval);
+  assert.ok(info.version);
+  assert.ok(info.body);
+  assert.ok(info.time);
+  // also the body fields
+  assert.ok(info.body.app);
+  assert.strictEqual(info.body.app, nsolidConfig.appName || 'untitled application');
+  assert.ok(info.body.arch);
+  assert.ok(info.body.cpuCores);
+  assert.ok(info.body.cpuModel);
+  assert.ok(info.body.execPath);
+  assert.ok(info.body.hostname);
+  assert.ok(info.body.id);
+  assert.ok(info.body.main);
+  assert.strictEqual(info.body.nodeEnv, nsolidConfig.nodeEnv || 'prod');
+  assert.ok(info.body.pid);
+  assert.ok(info.body.platform);
+  assert.ok(info.body.processStart);
+  assert.strictEqual(info.body.tags.length, nsolidConfig.tags ? nsolidConfig.tags.length : 0);
+  assert.ok(info.body.totalMem);
+  assert.deepStrictEqual(info.body.versions, process.versions);
+}
+
+const tests = [];
+
+tests.push({
+  name: 'should provide default values correctly',
+  test: async (playground) => {
+    return new Promise((resolve) => {
+      playground.bootstrap(mustSucceed((agentId) => {
+        const requestId = playground.zmqAgentBus.agentInfoRequest(agentId, mustSucceed((info) => {
+          checkInfoData(info, requestId, agentId);
+          resolve();
+        }));
+      }));
+    });
+  }
+});
+
+tests.push({
+  name: 'should also work with nsolid configuration',
+  test: async (playground) => {
+    return new Promise((resolve) => {
+      const bootstrapOpts = {
+        opts: {
+          env: {
+            NSOLID_APPNAME: 'myapp',
+            NSOLID_TAGS: 'tag1,tag2',
+            NODE_ENV: 'dev'
+          }
+        }
+      };
+
+      playground.bootstrap(bootstrapOpts, mustSucceed((agentId) => {
+        const requestId = playground.zmqAgentBus.agentInfoRequest(agentId, mustSucceed((info) => {
+          const nsolidConfig = {
+            appName: 'myapp',
+            tags: ['tag1', 'tag2'],
+            nodeEnv: 'dev'
+          };
+
+          checkInfoData(info, requestId, agentId, nsolidConfig);
+          resolve();
+        }));
+      }));
+    });
+  }
+});
+
+const config = {
+  commandBindAddr: 'tcp://*:9001',
+  dataBindAddr: 'tcp://*:9002',
+  bulkBindAddr: 'tcp://*:9003',
+  HWM: 0,
+  bulkHWM: 0,
+  commandTimeoutMilliseconds: 5000
+};
+
+
+const playground = new TestPlayground(config);
+await playground.startServer();
+
+for (const { name, test } of tests) {
+  console.log(`info command ${name}`);
+  await test(playground);
+  await playground.stopClient();
+}
+
+playground.stopServer();

--- a/test/agents/test-zmq-metrics.mjs
+++ b/test/agents/test-zmq-metrics.mjs
@@ -1,0 +1,305 @@
+// Flags: --expose-internals
+import { mustSucceed } from '../common/index.mjs';
+import assert from 'node:assert';
+import validators from 'internal/validators';
+import { TestPlayground } from '../common/nsolid-zmq-agent/index.js';
+
+const {
+  validateArray,
+  validateString,
+  validateNumber,
+  validateObject,
+  validateUint32
+} = validators;
+
+
+// Data has this format:
+// {
+//   agentId: 'db60f4163efd1e00fe23fd480e279c00415d38ce',
+//   requestId: '6ef826bc-c504-4ef2-a093-997fce309045',
+//   command: 'metrics',
+//   recorded: { seconds: 1704798405, nanoseconds: 620710478 },
+//   duration: 0,
+//   interval: 3000,
+//   version: 4,
+//   body: {
+//     processMetrics: {
+//       timestamp: 1704798405616,
+//       uptime: 0,
+//       systemUptime: 3761,
+//       freeMem: 24968327168,
+//       blockInputOpCount: 0,
+//       blockOutputOpCount: 0,
+//       ctxSwitchInvoluntaryCount: 0,
+//       ctxSwitchVoluntaryCount: 39,
+//       ipcReceivedCount: 0,
+//       ipcSentCount: 0,
+//       pageFaultHardCount: 0,
+//       pageFaultSoftCount: 3429,
+//       signalCount: 0,
+//       swapCount: 0,
+//       rss: 54542336,
+//       load1m: 0.82,
+//       load5m: 0.69,
+//       load15m: 0.78,
+//       cpuUserPercent: 50.021387,
+//       cpuSystemPercent: 4.652745,
+//       cpuPercent: 54.674132,
+//       title: '/home/sgimeno/nodesource/nsolid/out/Release/nsolid',
+//       user: 'sgimeno'
+//     },
+//     threadMetrics: [
+//       {
+//         threadId: 0,
+//         timestamp: 1704798405615,
+//         activeHandles: 2,
+//         activeRequests: 0,
+//         heapTotal: 4907008,
+//         totalHeapSizeExecutable: 262144,
+//         totalPhysicalSize: 4976640,
+//         totalAvailableSize: 4341636488,
+//         heapUsed: 4590920,
+//         heapSizeLimit: 4345298944,
+//         mallocedMemory: 360736,
+//         externalMem: 1650226,
+//         peakMallocedMemory: 572512,
+//         numberOfNativeContexts: 1,
+//         numberOfDetachedContexts: 0,
+//         gcCount: 0,
+//         gcForcedCount: 0,
+//         gcFullCount: 0,
+//         gcMajorCount: 0,
+//         dnsCount: 0,
+//         httpClientAbortCount: 0,
+//         httpClientCount: 0,
+//         httpServerAbortCount: 0,
+//         httpServerCount: 0,
+//         loopIdleTime: 19614540,
+//         loopIterations: 1,
+//         loopIterWithEvents: 1,
+//         eventsProcessed: 1,
+//         eventsWaiting: 1,
+//         providerDelay: 8456048,
+//         processingDelay: 0,
+//         loopTotalCount: 1,
+//         pipeServerCreatedCount: 0,
+//         pipeServerDestroyedCount: 0,
+//         pipeSocketCreatedCount: 1,
+//         pipeSocketDestroyedCount: 0,
+//         tcpServerCreatedCount: 0,
+//         tcpServerDestroyedCount: 0,
+//         tcpSocketCreatedCount: 0,
+//         tcpSocketDestroyedCount: 0,
+//         udpSocketCreatedCount: 0,
+//         udpSocketDestroyedCount: 0,
+//         promiseCreatedCount: 0,
+//         promiseResolvedCount: 0,
+//         fsHandlesOpenedCount: 0,
+//         fsHandlesClosedCount: 0,
+//         gcDurUs99Ptile: 0,
+//         gcDurUsMedian: 0,
+//         dns99Ptile: 0,
+//         dnsMedian: 0,
+//         httpClient99Ptile: 0,
+//         httpClientMedian: 0,
+//         httpServer99Ptile: 0,
+//         httpServerMedian: 0,
+//         loopUtilization: 0.137165,
+//         res5s: 0.001691,
+//         res1m: 0.000141,
+//         res5m: 0.000028,
+//         res15m: 0.000009,
+//         loopAvgTasks: 0,
+//         loopEstimatedLag: 0.0005,
+//         loopIdlePercent: 86.283493,
+//         threadName: ''
+//       }
+//     ]
+//   },
+//   time: 1704798405621,
+//   timeNS: '1704798405620710478'
+// }
+
+function checkProcessMetrics(processMetrics) {
+  validateObject(processMetrics, 'processMetrics');
+  validateNumber(processMetrics.timestamp, 'processMetrics.timestamp');
+  validateNumber(processMetrics.uptime, 'processMetrics.uptime');
+  validateNumber(processMetrics.systemUptime, 'processMetrics.systemUptime');
+  validateNumber(processMetrics.freeMem, 'processMetrics.freeMem');
+  validateUint32(processMetrics.blockInputOpCount, 'processMetrics.blockInputOpCount');
+  validateUint32(processMetrics.blockOutputOpCount, 'processMetrics.blockOutputOpCount');
+  validateUint32(processMetrics.ctxSwitchInvoluntaryCount, 'processMetrics.ctxSwitchInvoluntaryCount');
+  validateUint32(processMetrics.ctxSwitchVoluntaryCount, 'processMetrics.ctxSwitchVoluntaryCount');
+  validateUint32(processMetrics.ipcReceivedCount, 'processMetrics.ipcReceivedCount');
+  validateUint32(processMetrics.ipcSentCount, 'processMetrics.ipcSentCount');
+  validateUint32(processMetrics.pageFaultHardCount, 'processMetrics.pageFaultHardCount');
+  validateUint32(processMetrics.pageFaultSoftCount, 'processMetrics.pageFaultSoftCount');
+  validateUint32(processMetrics.signalCount, 'processMetrics.signalCount');
+  validateUint32(processMetrics.swapCount, 'processMetrics.swapCount');
+  validateNumber(processMetrics.rss, 'processMetrics.rss');
+  validateNumber(processMetrics.load1m, 'processMetrics.load1m');
+  validateNumber(processMetrics.load5m, 'processMetrics.load5m');
+  validateNumber(processMetrics.load15m, 'processMetrics.load15m');
+  validateNumber(processMetrics.cpuUserPercent, 'processMetrics.cpuUserPercent');
+  validateNumber(processMetrics.cpuSystemPercent, 'processMetrics.cpuSystemPercent');
+  validateNumber(processMetrics.cpuPercent, 'processMetrics.cpuPercent');
+  validateString(processMetrics.title, 'processMetrics.title');
+  validateString(processMetrics.user, 'processMetrics.user');
+}
+
+function checkThreadMetrics(threadMetrics) {
+  validateArray(threadMetrics, 'threadMetrics');
+  for (const threadMetric of threadMetrics) {
+    validateObject(threadMetric, 'threadMetric');
+    validateUint32(threadMetric.threadId, 'threadMetric.threadId');
+    validateNumber(threadMetric.timestamp, 'threadMetric.timestamp');
+    validateUint32(threadMetric.activeHandles, 'threadMetric.activeHandles');
+    validateUint32(threadMetric.activeRequests, 'threadMetric.activeRequests');
+    validateNumber(threadMetric.heapTotal, 'threadMetric.heapTotal');
+    validateNumber(threadMetric.totalHeapSizeExecutable, 'threadMetric.totalHeapSizeExecutable');
+    validateNumber(threadMetric.totalPhysicalSize, 'threadMetric.totalPhysicalSize');
+    validateNumber(threadMetric.totalAvailableSize, 'threadMetric.totalAvailableSize');
+    validateNumber(threadMetric.heapUsed, 'threadMetric.heapUsed');
+    validateNumber(threadMetric.heapSizeLimit, 'threadMetric.heapSizeLimit');
+    validateNumber(threadMetric.mallocedMemory, 'threadMetric.mallocedMemory');
+    validateNumber(threadMetric.externalMem, 'threadMetric.externalMem');
+    validateNumber(threadMetric.peakMallocedMemory, 'threadMetric.peakMallocedMemory');
+    validateUint32(threadMetric.numberOfNativeContexts, 'threadMetric.numberOfNativeContexts');
+    validateUint32(threadMetric.numberOfDetachedContexts, 'threadMetric.numberOfDetachedContexts');
+    validateUint32(threadMetric.gcCount, 'threadMetric.gcCount');
+    validateUint32(threadMetric.gcForcedCount, 'threadMetric.gcForcedCount');
+    validateUint32(threadMetric.gcFullCount, 'threadMetric.gcFullCount');
+    validateUint32(threadMetric.gcMajorCount, 'threadMetric.gcMajorCount');
+    validateUint32(threadMetric.dnsCount, 'threadMetric.dnsCount');
+    validateUint32(threadMetric.httpClientAbortCount, 'threadMetric.httpClientAbortCount');
+    validateUint32(threadMetric.httpClientCount, 'threadMetric.httpClientCount');
+    validateUint32(threadMetric.httpServerAbortCount, 'threadMetric.httpServerAbortCount');
+    validateUint32(threadMetric.httpServerCount, 'threadMetric.httpServerCount');
+    validateNumber(threadMetric.loopIdleTime, 'threadMetric.loopIdleTime');
+    validateUint32(threadMetric.loopIterations, 'threadMetric.loopIterations');
+    validateUint32(threadMetric.loopIterWithEvents, 'threadMetric.loopIterWithEvents');
+    validateUint32(threadMetric.eventsProcessed, 'threadMetric.eventsProcessed');
+    validateUint32(threadMetric.eventsWaiting, 'threadMetric.eventsWaiting');
+    validateNumber(threadMetric.providerDelay, 'threadMetric.providerDelay');
+    validateNumber(threadMetric.processingDelay, 'threadMetric.processingDelay');
+    validateUint32(threadMetric.loopTotalCount, 'threadMetric.loopTotalCount');
+    validateUint32(threadMetric.pipeServerCreatedCount, 'threadMetric.pipeServerCreatedCount');
+    validateUint32(threadMetric.pipeServerDestroyedCount, 'threadMetric.pipeServerDestroyedCount');
+    validateUint32(threadMetric.pipeSocketCreatedCount, 'threadMetric.pipeSocketCreatedCount');
+    validateUint32(threadMetric.pipeSocketDestroyedCount, 'threadMetric.pipeSocketDestroyedCount');
+    validateUint32(threadMetric.tcpServerCreatedCount, 'threadMetric.tcpServerCreatedCount');
+    validateUint32(threadMetric.tcpServerDestroyedCount, 'threadMetric.tcpServerDestroyedCount');
+    validateUint32(threadMetric.tcpSocketCreatedCount, 'threadMetric.tcpSocketCreatedCount');
+    validateUint32(threadMetric.tcpSocketDestroyedCount, 'threadMetric.tcpSocketDestroyedCount');
+    validateUint32(threadMetric.udpSocketCreatedCount, 'threadMetric.udpSocketCreatedCount');
+    validateUint32(threadMetric.udpSocketDestroyedCount, 'threadMetric.udpSocketDestroyedCount');
+    validateUint32(threadMetric.promiseCreatedCount, 'threadMetric.promiseCreatedCount');
+    validateUint32(threadMetric.promiseResolvedCount, 'threadMetric.promiseResolvedCount');
+    validateUint32(threadMetric.fsHandlesOpenedCount, 'threadMetric.fsHandlesOpenedCount');
+    validateUint32(threadMetric.fsHandlesClosedCount, 'threadMetric.fsHandlesClosedCount');
+    validateNumber(threadMetric.gcDurUs99Ptile, 'threadMetric.gcDurUs99Ptile');
+    validateNumber(threadMetric.gcDurUsMedian, 'threadMetric.gcDurUsMedian');
+    validateNumber(threadMetric.dns99Ptile, 'threadMetric.dns99Ptile');
+    validateNumber(threadMetric.dnsMedian, 'threadMetric.dnsMedian');
+    validateNumber(threadMetric.httpClient99Ptile, 'threadMetric.httpClient99Ptile');
+    validateNumber(threadMetric.httpClientMedian, 'threadMetric.httpClientMedian');
+    validateNumber(threadMetric.httpServer99Ptile, 'threadMetric.httpServer99Ptile');
+    validateNumber(threadMetric.httpServerMedian, 'threadMetric.httpServerMedian');
+    validateNumber(threadMetric.loopUtilization, 'threadMetric.loopUtilization');
+    validateNumber(threadMetric.res5s, 'threadMetric.res5s');
+    validateNumber(threadMetric.res1m, 'threadMetric.res1m');
+    validateNumber(threadMetric.res5m, 'threadMetric.res5m');
+    validateNumber(threadMetric.res15m, 'threadMetric.res15m');
+    validateNumber(threadMetric.loopAvgTasks, 'threadMetric.loopAvgTasks');
+    validateNumber(threadMetric.loopEstimatedLag, 'threadMetric.loopEstimatedLag');
+    validateNumber(threadMetric.loopIdlePercent, 'threadMetric.loopIdlePercent');
+    validateString(threadMetric.threadName, 'threadMetric.threadName');
+  }
+}
+
+
+function checkMetricsData(metrics, requestId, agentId, threads) {
+  assert.strictEqual(metrics.requestId, requestId);
+  assert.strictEqual(metrics.agentId, agentId);
+  assert.strictEqual(metrics.command, 'metrics');
+  // From here check at least that all the fields are present
+  assert.ok(metrics.recorded);
+  assert.ok(metrics.recorded.seconds);
+  assert.ok(metrics.recorded.nanoseconds);
+  assert.ok(metrics.duration != null);
+  assert.ok(metrics.interval);
+  assert.ok(metrics.version);
+  assert.ok(metrics.body);
+  assert.ok(metrics.time);
+  // also the body fields
+  assert.ok(metrics.body.processMetrics);
+  assert.ok(metrics.body.threadMetrics);
+
+  assert.strictEqual(metrics.body.threadMetrics.length, threads.length);
+
+  // Validate processMetrics and threadMetrics
+  checkProcessMetrics(metrics.body.processMetrics);
+  checkThreadMetrics(metrics.body.threadMetrics);
+}
+
+const tests = [];
+
+tests.push({
+  name: 'should provide the correct values with only the main thread',
+  test: async (playground) => {
+    return new Promise((resolve) => {
+      playground.bootstrap(mustSucceed(async (agentId) => {
+        const workers = await playground.client.workers();
+        assert.strictEqual(workers.length, 0);
+        const requestId = playground.zmqAgentBus.agentMetricsRequest(agentId, mustSucceed((metrics) => {
+          checkMetricsData(metrics, requestId, agentId, [ 0, ...workers]);
+          resolve();
+        }));
+      }));
+    });
+  }
+});
+
+tests.push({
+  name: 'should provide the correct values with some workers',
+  test: async (playground) => {
+    return new Promise((resolve) => {
+      const opts = {
+        args: [ '-w', 2 ],
+        opts: { env: { NSOLID_INTERVAL: 200 } }
+      };
+
+      playground.bootstrap(opts, mustSucceed(async (agentId) => {
+        const workers = await playground.client.workers();
+        assert.strictEqual(workers.length, 2);
+        setTimeout(() => {
+          const requestId = playground.zmqAgentBus.agentMetricsRequest(agentId, mustSucceed((metrics) => {
+            checkMetricsData(metrics, requestId, agentId, [ 0, ...workers]);
+            resolve();
+          }));
+        }, 400);
+      }));
+    });
+  }
+});
+
+const config = {
+  commandBindAddr: 'tcp://*:9001',
+  dataBindAddr: 'tcp://*:9002',
+  bulkBindAddr: 'tcp://*:9003',
+  HWM: 0,
+  bulkHWM: 0,
+  commandTimeoutMilliseconds: 5000
+};
+
+
+const playground = new TestPlayground(config);
+await playground.startServer();
+
+for (const { name, test } of tests) {
+  console.log(`metrics command ${name}`);
+  await test(playground);
+  await playground.stopClient();
+}
+
+playground.stopServer();

--- a/test/agents/test-zmq-packages.mjs
+++ b/test/agents/test-zmq-packages.mjs
@@ -1,0 +1,154 @@
+import { mustSucceed } from '../common/index.mjs';
+import assert from 'node:assert';
+import { TestPlayground } from '../common/nsolid-zmq-agent/index.js';
+
+function assertIncludes(actualValues, expectedValues) {
+  for (const expectedValue of expectedValues) {
+    assert.ok(actualValues.includes(expectedValue));
+  }
+}
+
+// Data has this format:
+// {
+//   agentId: 'd0cd9326d8bc07009f7bb5e9aa123b001ce85c56',
+//   requestId: 'd1bc1c33-1239-4322-bdf2-986b9aa5c683',
+//   command: 'packages',
+//   recorded: { seconds: 1704736859, nanoseconds: 511473832 },
+//   duration: 0,
+//   interval: 3000,
+//   version: 4,
+//   body: {
+//     packages: [
+//       {
+//         path: '/path/to/nsolid/test/common/nsolid-zmq-agent/node_modules/debug',
+//         name: 'debug',
+//         version: '3.1.0',
+//         main: './src/index.js',
+//         dependencies: [ '../ms' ],
+//         required: false
+//       },
+//       {
+//         path: '/path/to/nsolid/test/common/nsolid-zmq-agent/node_modules/ms',
+//         name: 'ms',
+//         version: '2.0.0',
+//         main: './index',
+//         dependencies: [],
+//         required: false
+//       },
+//       {
+//         path: '/path/to/nsolid/test/common/nsolid-zmq-agent/node_modules/nan',
+//         name: 'nan',
+//         version: '2.17.0',
+//         main: 'include_dirs.js',
+//         dependencies: [],
+//         required: false
+//       },
+//       {
+//         path: '/path/to/nsolid/test/common/nsolid-zmq-agent/node_modules/node-gyp-build',
+//         name: 'node-gyp-build',
+//         version: '4.7.1',
+//         main: 'index.js',
+//         dependencies: [],
+//         required: false
+//       },
+//       {
+//         path: '/path/to/nsolid/test/common/nsolid-zmq-agent/node_modules/z85',
+//         name: 'z85',
+//         version: '0.0.2',
+//         main: 'index.js',
+//         dependencies: [],
+//         required: false
+//       },
+//       {
+//         path: '/path/to/nsolid/test/common/nsolid-zmq-agent/node_modules/zeromq',
+//         name: 'zeromq',
+//         version: '5.3.1',
+//         main: 'index',
+//         dependencies: [ '../nan', '../node-gyp-build' ],
+//         required: false
+//       },
+//       {
+//         path: '/path/to/nsolid/test/common/nsolid-zmq-agent/node_modules/zmq-zap',
+//         name: 'zmq-zap',
+//         version: '0.0.3',
+//         main: 'index.js',
+//         dependencies: [ '../z85', '../debug' ],
+//         required: false
+//       }
+//     ]
+//   },
+//   time: 1704736859511,
+//   timeNS: '1704736859511473832'
+// }
+
+function checkPackagesData(packages, requestId, agentId) {
+  assert.strictEqual(packages.requestId, requestId);
+  assert.strictEqual(packages.agentId, agentId);
+  assert.strictEqual(packages.command, 'packages');
+  // From here check at least that all the fields are present
+  assert.ok(packages.recorded);
+  assert.ok(packages.recorded.seconds);
+  assert.ok(packages.recorded.nanoseconds);
+  assert.ok(packages.duration != null);
+  assert.ok(packages.interval);
+  assert.ok(packages.version);
+  assert.ok(packages.body);
+  assert.ok(packages.time);
+  // also the body fields
+  assert.ok(packages.body.packages);
+  assert.ok(packages.body.packages.length);
+  for (const pkg of packages.body.packages) {
+    assert.ok(pkg.path);
+    assert.ok(pkg.name);
+    assert.ok(pkg.version);
+    assert.ok(pkg.main);
+    assert.ok(pkg.dependencies);
+    assert.strictEqual(pkg.required, false);
+  }
+
+  const packagesNames = packages.body.packages.map((pkg) => pkg.name);
+  assertIncludes(packagesNames, ['debug', 'ms', 'nan', 'node-gyp-build', 'z85', 'zeromq', 'zmq-zap']);
+
+  const packagesMajorVersions = packages.body.packages.map((pkg) => pkg.version.split('.')[0]);
+  assertIncludes(packagesMajorVersions, ['3', '2', '2', '4', '0', '5', '0']);
+
+  const packagesMains = packages.body.packages.map((pkg) => pkg.main);
+  assertIncludes(packagesMains, ['./src/index.js', './index', 'include_dirs.js', 'index.js', 'index']);
+}
+
+const tests = [];
+
+tests.push({
+  name: 'should provide default values correctly',
+  test: async (playground) => {
+    return new Promise((resolve) => {
+      playground.bootstrap(mustSucceed((agentId) => {
+        const requestId = playground.zmqAgentBus.agentPackagesRequest(agentId, mustSucceed((packages) => {
+          checkPackagesData(packages, requestId, agentId);
+          resolve();
+        }));
+      }));
+    });
+  }
+});
+
+const config = {
+  commandBindAddr: 'tcp://*:9001',
+  dataBindAddr: 'tcp://*:9002',
+  bulkBindAddr: 'tcp://*:9003',
+  HWM: 0,
+  bulkHWM: 0,
+  commandTimeoutMilliseconds: 5000
+};
+
+
+const playground = new TestPlayground(config);
+await playground.startServer();
+
+for (const { name, test } of tests) {
+  console.log(`packages command ${name}`);
+  await test(playground);
+  await playground.stopClient();
+}
+
+playground.stopServer();

--- a/test/agents/test-zmq-ping.mjs
+++ b/test/agents/test-zmq-ping.mjs
@@ -1,0 +1,83 @@
+// Flags: --expose-internals
+import { mustSucceed } from '../common/index.mjs';
+import assert from 'node:assert';
+import validators from 'internal/validators';
+import { TestPlayground } from '../common/nsolid-zmq-agent/index.js';
+
+const {
+  validateBoolean,
+  validateInteger,
+  validateObject,
+  validateUint32,
+} = validators;
+
+// Data has this format:
+// {
+//   agentId: 'b41f52d0cf1e2100affbd3a0c2766200cb2f7427',
+//   requestId: '81ca8fa0-03a4-4051-a017-c6fc659aea3a',
+//   command: 'ping',
+//   recorded: { seconds: 1703172421, nanoseconds: 333469660 },
+//   duration: 0,
+//   interval: 3000,
+//   version: 4,
+//   body: { pong: true },
+//   time: 1703172421333,
+//   timeNS: '1703172421333469660'
+// }
+
+function checkPingData(data, requestId, agentId) {
+  console.dir(data, { depth: null });
+  assert.strictEqual(data.requestId, requestId);
+  assert.strictEqual(data.agentId, agentId);
+  assert.strictEqual(data.command, 'ping');
+  // From here check at least that all the fields are present
+  validateObject(data.recorded, 'recorded');
+  validateUint32(data.recorded.seconds, 'recorded.seconds');
+  validateUint32(data.recorded.nanoseconds, 'recorded.nanoseconds');
+  validateUint32(data.duration, 'duration');
+  validateUint32(data.interval, 'interval');
+  assert.strictEqual(data.version, 4);
+  validateObject(data.body, 'body');
+  validateInteger(data.time, 'time');
+  // also the body fields
+  validateBoolean(data.body.pong, 'body.pong');
+  assert.ok(data.body.pong);
+}
+
+const tests = [];
+
+tests.push({
+  name: 'should just work',
+  test: async (playground) => {
+    return new Promise((resolve) => {
+      playground.bootstrap(mustSucceed((agentId) => {
+        const requestId =
+          playground.zmqAgentBus.agentPingRequest(agentId, mustSucceed((ping) => {
+            checkPingData(ping, requestId, agentId);
+            resolve();
+          }));
+      }));
+    });
+  }
+});
+
+const config = {
+  commandBindAddr: 'tcp://*:9001',
+  dataBindAddr: 'tcp://*:9002',
+  bulkBindAddr: 'tcp://*:9003',
+  HWM: 0,
+  bulkHWM: 0,
+  commandTimeoutMilliseconds: 5000
+};
+
+
+const playground = new TestPlayground(config);
+await playground.startServer();
+
+for (const { name, test } of tests) {
+  console.log(`ping command ${name}`);
+  await test(playground);
+  await playground.stopClient();
+}
+
+playground.stopServer();

--- a/test/agents/test-zmq-profile.mjs
+++ b/test/agents/test-zmq-profile.mjs
@@ -1,0 +1,350 @@
+import { mustCall, mustSucceed } from '../common/index.mjs';
+import assert from 'node:assert';
+import {
+  checkExitData,
+  TestPlayground,
+} from '../common/nsolid-zmq-agent/index.js';
+
+/**
+ * data has this format:
+ * {
+    agentId: '1a3ff062d4c016000bd4a8bd33f22c002d6ed6b3',
+    requestId: '5625b2d3-55b7-4660-84d1-5ad6f003f933',
+    command: 'profile',
+    duration: 112,
+    metadata: { reason: 'unspecified' },
+    complete: false,
+    threadId: 0,
+    version: 4,
+    bulkId: '5625b2d3-55b7-4660-84d1-5ad6f003f933'
+  }
+ */
+function checkProfileData(requestId, options, agentId, data, complete, onExit = false) {
+  assert.strictEqual(data.requestId, requestId);
+  assert.strictEqual(data.agentId, agentId);
+  assert.strictEqual(data.command, 'profile');
+  if (onExit) {
+    assert.ok(data.duration < options.duration);
+  } else {
+    assert.ok(data.duration > options.duration);
+  }
+  assert.strictEqual(data.complete, complete);
+  assert.strictEqual(data.threadId, options.threadId);
+  assert.strictEqual(data.version, 4);
+  assert.strictEqual(data.bulkId, requestId);
+}
+
+function checkExitSequence(eventType, data, requestId, options, agentId) {
+  assert.ok(eventType === 'asset-received' || eventType === 'agent-exit');
+  if (eventType === 'asset-received') {
+    checkProfileData(requestId, options, agentId, data, true, true);
+  } else {
+    checkExitData(data, { exit_code: 0, error: null });
+  }
+}
+
+const tests = [];
+
+tests.push({
+  name: 'should work for the main thread',
+  test: async (playground) => {
+    return new Promise((resolve) => {
+      let events = 0;
+      let profile = '';
+      let requestId;
+      const options = {
+        duration: 100,
+        threadId: 0,
+      };
+
+      playground.bootstrap(mustSucceed((agentId) => {
+        requestId = playground.zmqAgentBus.agentProfileStart(agentId, options);
+      }), (eventType, agentId, data) => {
+        switch (++events) {
+          case 1:
+            assert.strictEqual(eventType, 'asset-data-packet');
+            if (data.packet.length > 0) {
+              checkProfileData(requestId, options, agentId, data.metadata, false);
+              profile += data.packet;
+              --events;
+            } else {
+              checkProfileData(requestId, options, agentId, data.metadata, true);
+            }
+            break;
+          case 2:
+            assert.strictEqual(eventType, 'asset-received');
+            checkProfileData(requestId, options, agentId, data, true);
+            JSON.parse(profile);
+            resolve();
+        }
+      });
+    });
+  },
+});
+
+tests.push({
+  name: 'should work for worker threads',
+  test: async (playground) => {
+    return new Promise((resolve) => {
+      let events = 0;
+      let profile = '';
+      let requestId;
+      const options = {
+        duration: 100,
+      };
+
+      const opts = {
+        args: [ '-w', 1 ],
+      };
+
+      playground.bootstrap(opts, mustSucceed(async (agentId) => {
+        // Need to get the id's of the worker threads from the metrics first.
+        const workers = await playground.client.workers();
+        options.threadId = workers[0];
+        requestId = playground.zmqAgentBus.agentProfileStart(agentId, options);
+      }), (eventType, agentId, data) => {
+        switch (++events) {
+          case 1:
+            assert.strictEqual(eventType, 'asset-data-packet');
+            if (data.packet.length > 0) {
+              checkProfileData(requestId, options, agentId, data.metadata, false);
+              profile += data.packet;
+              --events;
+            } else {
+              checkProfileData(requestId, options, agentId, data.metadata, true);
+            }
+            break;
+          case 2:
+            assert.strictEqual(eventType, 'asset-received');
+            checkProfileData(requestId, options, agentId, data, true);
+            JSON.parse(profile);
+            resolve();
+        }
+      });
+    });
+  },
+});
+
+tests.push({
+  name: 'should return 410 if sent to a non-existant thread',
+  test: async (playground) => {
+    return new Promise((resolve) => {
+      const options = {
+        duration: 100,
+        threadId: 10,
+      };
+
+      playground.bootstrap(mustSucceed((agentId) => {
+        playground.zmqAgentBus.agentProfileStart(agentId, options, mustCall((err) => {
+          assert.strictEqual(err.code, 410);
+          assert.strictEqual(err.message, 'Thread already gone');
+          resolve();
+        }));
+      }));
+    });
+  },
+});
+
+tests.push({
+  name: 'should return 422 if invalid threadId field',
+  test: async (playground) => {
+    return new Promise((resolve) => {
+      const options = {
+        duration: 100,
+        threadId: 'wth',
+      };
+
+      playground.bootstrap(mustSucceed((agentId) => {
+        playground.zmqAgentBus.agentProfileStart(agentId, options, mustCall((err) => {
+          assert.strictEqual(err.code, 422);
+          assert.strictEqual(err.message, 'Invalid arguments');
+          resolve();
+        }));
+      }));
+    });
+  },
+});
+
+tests.push({
+  name: 'should return 422 if invalid duration field',
+  test: async (playground) => {
+    return new Promise((resolve) => {
+      const options = {
+        duration: 'wth',
+      };
+
+      playground.bootstrap(mustSucceed((agentId) => {
+        playground.zmqAgentBus.agentProfileStart(agentId, options, mustCall((err) => {
+          assert.strictEqual(err.code, 422);
+          assert.strictEqual(err.message, 'Invalid arguments');
+          resolve();
+        }));
+      }));
+    });
+  },
+});
+
+tests.push({
+  name: 'should return 422 no args field',
+  test: async (playground) => {
+    return new Promise((resolve) => {
+      const options = null;
+
+      playground.bootstrap(mustSucceed((agentId) => {
+        playground.zmqAgentBus.agentProfileStart(agentId, options, mustCall((err) => {
+          assert.strictEqual(err.code, 422);
+          assert.strictEqual(err.message, 'Invalid arguments');
+          resolve();
+        }));
+      }));
+    });
+  },
+});
+
+tests.push({
+  name: 'should return 409 if profile in progress in main thread',
+  test: async (playground) => {
+    return new Promise((resolve) => {
+      let events = 0;
+      let profile = '';
+      let requestId;
+      const options = {
+        duration: 100,
+        threadId: 0,
+      };
+
+      playground.bootstrap(mustSucceed((agentId) => {
+        requestId = playground.zmqAgentBus.agentProfileStart(agentId, options);
+        playground.zmqAgentBus.agentProfileStart(agentId, options, mustCall((err) => {
+          assert.strictEqual(err.code, 409);
+          assert.strictEqual(err.message, 'Profile already in progress');
+        }));
+      }), (eventType, agentId, data) => {
+        switch (++events) {
+          case 1:
+            assert.strictEqual(eventType, 'asset-data-packet');
+            if (data.packet.length > 0) {
+              checkProfileData(requestId, options, agentId, data.metadata, false);
+              profile += data.packet;
+              --events;
+            } else {
+              checkProfileData(requestId, options, agentId, data.metadata, true);
+            }
+            break;
+          case 2:
+            assert.strictEqual(eventType, 'asset-received');
+            checkProfileData(requestId, options, agentId, data, true);
+            JSON.parse(profile);
+            resolve();
+        }
+      });
+    });
+  },
+});
+
+tests.push({
+  name: 'should return 409 if profile in progress in worker',
+  test: async (playground) => {
+    return new Promise((resolve) => {
+      let events = 0;
+      let profile = '';
+      let requestId;
+      const options = {
+        duration: 100,
+      };
+
+      const opts = {
+        args: [ '-w', 1 ],
+      };
+      playground.bootstrap(opts, mustSucceed(async (agentId) => {
+        // Need to get the id's of the worker threads from the metrics first.
+        const workers = await playground.client.workers();
+        options.threadId = workers[0];
+        requestId = playground.zmqAgentBus.agentProfileStart(agentId, options);
+        playground.zmqAgentBus.agentProfileStart(agentId, options, mustCall((err) => {
+          assert.strictEqual(err.code, 409);
+          assert.strictEqual(err.message, 'Profile already in progress');
+        }));
+      }), (eventType, agentId, data) => {
+        switch (++events) {
+          case 1:
+            assert.strictEqual(eventType, 'asset-data-packet');
+            if (data.packet.length > 0) {
+              checkProfileData(requestId, options, agentId, data.metadata, false);
+              profile += data.packet;
+              --events;
+            } else {
+              checkProfileData(requestId, options, agentId, data.metadata, true);
+            }
+            break;
+          case 2:
+            assert.strictEqual(eventType, 'asset-received');
+            checkProfileData(requestId, options, agentId, data, true);
+            JSON.parse(profile);
+            resolve();
+        }
+      });
+    });
+  },
+});
+
+tests.push({
+  name: 'should end an ongoing profile before exiting',
+  test: async (playground) => {
+    return new Promise((resolve) => {
+      let events = 0;
+      let requestId;
+      const options = {
+        duration: 1000,
+        threadId: 0,
+      };
+
+      playground.bootstrap(mustSucceed(async (agentId) => {
+        requestId = playground.zmqAgentBus.agentProfileStart(agentId, options);
+        const exit = await playground.client.shutdown(0);
+        assert.ok(exit);
+        assert.strictEqual(exit.code, 0);
+        assert.strictEqual(exit.signal, null);
+        resolve();
+      }), (eventType, agentId, data) => {
+        switch (++events) {
+          case 1:
+            assert.strictEqual(eventType, 'asset-data-packet');
+            checkProfileData(requestId, options, agentId, data.metadata, false, true);
+            break;
+          case 2:
+            assert.strictEqual(eventType, 'asset-data-packet');
+            checkProfileData(requestId, options, agentId, data.metadata, true, true);
+            break;
+          case 3:
+            checkExitSequence(eventType, data, requestId, options, agentId);
+            break;
+          case 4:
+            checkExitSequence(eventType, data, requestId, options, agentId);
+        }
+      });
+    });
+  },
+});
+
+
+const config = {
+  commandBindAddr: 'tcp://*:9001',
+  dataBindAddr: 'tcp://*:9002',
+  bulkBindAddr: 'tcp://*:9003',
+  HWM: 0,
+  bulkHWM: 0,
+  commandTimeoutMilliseconds: 5000,
+};
+
+
+const playground = new TestPlayground(config);
+await playground.startServer();
+
+for (const { name, test } of tests) {
+  console.log(`cpu profiling ${name}`);
+  await test(playground);
+  await playground.stopClient();
+}
+
+playground.stopServer();

--- a/test/agents/test-zmq-reconfigure.mjs
+++ b/test/agents/test-zmq-reconfigure.mjs
@@ -1,0 +1,177 @@
+// Flags: --expose-internals
+import { mustSucceed } from '../common/index.mjs';
+import assert from 'node:assert';
+import validators from 'internal/validators';
+import { TestPlayground } from '../common/nsolid-zmq-agent/index.js';
+
+const {
+  validateInteger,
+  validateObject,
+  validateUint32,
+} = validators;
+
+// Data has this format:
+// {
+//   agentId: '523e62bcab8e56003929af2dcb7381002f471c29',
+//   requestId: 'f4e9d0b7-754d-44ba-922e-b68136b1921e',
+//   command: 'reconfigure',
+//   recorded: { seconds: 1704814130, nanoseconds: 273547654 },
+//   duration: 0,
+//   interval: 3000,
+//   version: 4,
+//   body: {
+//     app: 'untitled application',
+//     blockedLoopThreshold: 200,
+//     command: 'localhost:9001',
+//     disablePackageScan: false,
+//     env: 'prod',
+//     hostname: 'sgimeno-N8xxEZ',
+//     iisNode: false,
+//     interval: 3000,
+//     pauseMetrics: false,
+//     promiseTracking: false,
+//     pubkey: 'oX1><^wd#q69Kh2NqT<EXtO*baE8^^f=VS<P[5ek',
+//     statsdBucket: 'nsolid.${env}.${app}.${hostname}.${shortId}',
+//     tags: [],
+//     tracingEnabled: false,
+//     tracingModulesBlacklist: 0,
+//     trackGlobalPackages: false
+//   },
+//   time: 1704814130274,
+//   timeNS: '1704814130273547654'
+// }
+
+function checkReconfigureData(reconfigure, requestId, agentId, nsolidConfig) {
+  assert.strictEqual(reconfigure.requestId, requestId);
+  assert.strictEqual(reconfigure.agentId, agentId);
+  assert.strictEqual(reconfigure.command, 'reconfigure');
+  // From here check at least that all the fields are present
+  validateObject(reconfigure.recorded, 'recorded');
+  validateUint32(reconfigure.recorded.seconds, 'recorded.seconds');
+  validateUint32(reconfigure.recorded.nanoseconds, 'recorded.nanoseconds');
+  validateUint32(reconfigure.duration, 'duration');
+  validateUint32(reconfigure.interval, 'interval');
+  assert.strictEqual(reconfigure.version, 4);
+  validateObject(reconfigure.body, 'body');
+  validateInteger(reconfigure.time, 'time');
+  // also the body fields
+  assert.deepStrictEqual(reconfigure.body, nsolidConfig);
+}
+
+const tests = [];
+
+tests.push({
+  name: 'should provide current config correctly',
+  test: async (playground) => {
+    return new Promise((resolve) => {
+      playground.bootstrap(mustSucceed((agentId) => {
+        const requestId = playground.zmqAgentBus.agentReconfigureRequest(agentId, null, mustSucceed(async (reconf) => {
+          const nsolidConfig = await playground.client.config();
+          checkReconfigureData(reconf, requestId, agentId, nsolidConfig);
+          resolve();
+        }));
+      }));
+    });
+  }
+});
+
+async function sendReconfigure(zmqAgentBus, agentId, config) {
+  return new Promise((resolve, reject) => {
+    const requestId = zmqAgentBus.agentReconfigureRequest(agentId, config, (err, reconfigure) => {
+      if (err) {
+        reject(err);
+      } else {
+        resolve({ requestId, reconfigure });
+      }
+    });
+  });
+}
+
+const validationErrors = [
+  [ { blockedLoopThreshold: '3000' }, "'blockedLoopThreshold' should be an unsigned int" ],
+  [ { interval: '3000' }, "'interval' should be an unsigned int" ],
+  [ { pauseMetrics: 'yes' }, "'pauseMetrics' should be a boolean" ],
+  [ { promiseTracking: 'yes' }, "'promiseTracking' should be a boolean" ],
+  [ { redactSnapshots: 'yes' }, "'redactSnapshots' should be a boolean" ],
+  [ { statsd: true }, "'statsd' should be a string" ],
+  [ { statsdBucket: true }, "'statsdBucket' should be a string" ],
+  [ { statsdTags: true }, "'statsdTags' should be a string" ],
+  [ { tags: 'yes' }, "'tags' should be an array of strings" ],
+  [ { tags: [ true ] }, "'tags' should be an array of strings" ],
+  [ { tracingEnabled: 'yes' }, "'tracingEnabled' should be a boolean" ],
+  [ { tracingModulesBlacklist: 'yes' }, "'tracingModulesBlacklist' should be an unsigned int" ],
+];
+
+tests.push({
+  name: 'should return validation error if invalid config is provided',
+  test: async (playground) => {
+    return new Promise((resolve) => {
+      playground.bootstrap(mustSucceed(async (agentId) => {
+        for (const [config, errorMsg] of validationErrors) {
+          await assert.rejects(async () => {
+            await sendReconfigure(playground.zmqAgentBus, agentId, config);
+          }, {
+            code: 422,
+            message: errorMsg
+          });
+        }
+
+        resolve();
+      }));
+    });
+  }
+});
+
+const newConfigs = [
+  [ 'blockedLoopThreshold', 8000 ],
+  [ 'interval', 5000 ],
+  [ 'pauseMetrics', true ],
+  [ 'promiseTracking', true ],
+  [ 'redactSnapshots', true ],
+  [ 'statsd', 'localhost:8125' ],
+  // eslint-disable-next-line no-template-curly-in-string
+  [ 'statsdBucket', 'nsolidtest.${env}.${app}.${hostname}.${shortId}' ],
+  [ 'statsdTags', 'tag1,tag2' ],
+  [ 'tags', [ 'tag1', 'tag2' ] ],
+  [ 'tracingEnabled', true ],
+  [ 'tracingModulesBlacklist', 1 ],
+];
+
+tests.push({
+  name: 'should return new config if valid config is provided',
+  test: async (playground) => {
+    return new Promise((resolve) => {
+      playground.bootstrap(mustSucceed(async (agentId) => {
+        for (const [key, val] of newConfigs) {
+          const { requestId, reconfigure } = await sendReconfigure(playground.zmqAgentBus, agentId, { [key]: val });
+          assert.deepStrictEqual(reconfigure.body[key], val);
+          const nsolidConfig = await playground.client.config();
+          checkReconfigureData(reconfigure, requestId, agentId, nsolidConfig);
+        }
+
+        resolve();
+      }));
+    });
+  }
+});
+
+const config = {
+  commandBindAddr: 'tcp://*:9001',
+  dataBindAddr: 'tcp://*:9002',
+  bulkBindAddr: 'tcp://*:9003',
+  HWM: 0,
+  bulkHWM: 0,
+  commandTimeoutMilliseconds: 5000
+};
+
+
+const playground = new TestPlayground(config);
+await playground.startServer();
+
+for (const { name, test } of tests) {
+  console.log(`reconfigure command ${name}`);
+  await test(playground);
+  await playground.stopClient();
+}
+
+playground.stopServer();

--- a/test/agents/test-zmq-snapshot.mjs
+++ b/test/agents/test-zmq-snapshot.mjs
@@ -1,0 +1,255 @@
+import { mustCall, mustSucceed } from '../common/index.mjs';
+import assert from 'node:assert';
+import { TestPlayground } from '../common/nsolid-zmq-agent/index.js';
+
+/**
+ * data has this format:
+ * {
+    agentId: '1a3ff062d4c016000bd4a8bd33f22c002d6ed6b3',
+    requestId: '5625b2d3-55b7-4660-84d1-5ad6f003f933',
+    command: 'snapshot',
+    metadata: { reason: 'unspecified' },
+    complete: false,
+    threadId: 0,
+    version: 4,
+    bulkId: '5625b2d3-55b7-4660-84d1-5ad6f003f933'
+  }
+ */
+function checkSnapshotData(requestId, options, agentId, data, complete) {
+  assert.strictEqual(data.requestId, requestId);
+  assert.strictEqual(data.agentId, agentId);
+  assert.strictEqual(data.command, 'snapshot');
+  assert.strictEqual(data.complete, complete);
+  assert.strictEqual(data.threadId, options.threadId);
+  assert.strictEqual(data.version, 4);
+  assert.strictEqual(data.bulkId, requestId);
+}
+
+const tests = [];
+
+tests.push({
+  name: 'should work for the main thread',
+  test: async (playground) => {
+    return new Promise((resolve) => {
+      let events = 0;
+      let requestId;
+      let snapshot = '';
+      const options = {
+        threadId: 0
+      };
+
+      const bootstrapOpts = {
+        // Just to be sure we don't receive the loop_blocked event
+        opts: { env: { NSOLID_BLOCKED_LOOP_THRESHOLD: 10000 } }
+      };
+
+      playground.bootstrap(bootstrapOpts, mustSucceed((agentId) => {
+        requestId = playground.zmqAgentBus.agentSnapshotRequest(agentId, options);
+      }), (eventType, agentId, data) => {
+        switch (++events) {
+          case 1:
+            assert.strictEqual(eventType, 'asset-data-packet');
+            if (data.packet.length > 0) {
+              checkSnapshotData(requestId, options, agentId, data.metadata, false);
+              snapshot += data.packet;
+              --events;
+            } else {
+              checkSnapshotData(requestId, options, agentId, data.metadata, true);
+            }
+            break;
+          case 2:
+            assert.strictEqual(eventType, 'asset-received');
+            checkSnapshotData(requestId, options, agentId, data, true);
+            JSON.parse(snapshot);
+            resolve();
+        }
+      });
+    });
+  }
+});
+
+tests.push({
+  name: 'should work for worker threads',
+  test: async (playground) => {
+    return new Promise((resolve) => {
+      let events = 0;
+      let requestId;
+      let snapshot = '';
+      const options = {
+      };
+
+      const bootstrapOpts = {
+        args: [ '-w', 1 ],
+        // Just to be sure we don't receive the loop_blocked event
+        opts: { env: { NSOLID_BLOCKED_LOOP_THRESHOLD: 10000 } }
+      };
+
+      playground.bootstrap(bootstrapOpts, mustSucceed(async (agentId) => {
+        // Need to get the id's of the worker threads from the metrics first.
+        const workers = await playground.client.workers();
+        options.threadId = workers[0];
+        requestId = playground.zmqAgentBus.agentSnapshotRequest(agentId, options);
+      }), (eventType, agentId, data) => {
+        switch (++events) {
+          case 1:
+            assert.strictEqual(eventType, 'asset-data-packet');
+            if (data.packet.length > 0) {
+              checkSnapshotData(requestId, options, agentId, data.metadata, false);
+              snapshot += data.packet;
+              --events;
+            } else {
+              checkSnapshotData(requestId, options, agentId, data.metadata, true);
+            }
+            break;
+          case 2:
+            assert.strictEqual(eventType, 'asset-received');
+            checkSnapshotData(requestId, options, agentId, data, true);
+            JSON.parse(snapshot);
+            resolve();
+        }
+      });
+    });
+  }
+});
+
+tests.push({
+  name: 'should return 410 if sent to a non-existant thread',
+  test: async (playground) => {
+    return new Promise((resolve) => {
+      const options = {
+        threadId: 10
+      };
+
+      playground.bootstrap(mustSucceed((agentId) => {
+        playground.zmqAgentBus.agentSnapshotRequest(agentId, options, mustCall((err) => {
+          assert.strictEqual(err.code, 410);
+          assert.strictEqual(err.message, 'Thread already gone');
+          resolve();
+        }));
+      }));
+    });
+  }
+});
+
+tests.push({
+  name: 'should return 422 if invalid threadId field',
+  test: async (playground) => {
+    return new Promise((resolve) => {
+      const options = {
+        threadId: 'wth'
+      };
+
+      playground.bootstrap(mustSucceed((agentId) => {
+        playground.zmqAgentBus.agentSnapshotRequest(agentId, options, mustCall((err) => {
+          assert.strictEqual(err.code, 422);
+          assert.strictEqual(err.message, 'Invalid arguments');
+          resolve();
+        }));
+      }));
+    });
+  }
+});
+
+tests.push({
+  name: 'should return 422 if invalid disableSnapshots config',
+  test: async (playground) => {
+    return new Promise((resolve) => {
+      const options = {
+        threadId: 0
+      };
+
+      const bootstrapOpts = {
+        opts: { env: { NSOLID_DISABLE_SNAPSHOTS: 1 } }
+      };
+
+      playground.bootstrap(bootstrapOpts, mustSucceed((agentId) => {
+        playground.zmqAgentBus.agentSnapshotRequest(agentId, options, mustCall((err) => {
+          assert.strictEqual(err.code, 422);
+          assert.strictEqual(err.message, 'Invalid arguments');
+          resolve();
+        }));
+      }));
+    });
+  }
+});
+
+tests.push({
+  name: 'should return 422 no args field',
+  test: async (playground) => {
+    return new Promise((resolve) => {
+      const options = null;
+
+      playground.bootstrap(mustSucceed((agentId) => {
+        playground.zmqAgentBus.agentSnapshotRequest(agentId, options, mustCall((err) => {
+          assert.strictEqual(err.code, 422);
+          assert.strictEqual(err.message, 'Invalid arguments');
+          resolve();
+        }));
+      }));
+    });
+  }
+});
+
+tests.push({
+  name: 'should return 409 if snapshot in progress',
+  test: async (playground) => {
+    return new Promise((resolve) => {
+      let events = 0;
+      let requestId;
+      const options = {
+        threadId: 0
+      };
+
+      const bootstrapOpts = {
+        // Just to be sure we don't receive the loop_blocked event
+        opts: { env: { NSOLID_BLOCKED_LOOP_THRESHOLD: 10000 } }
+      };
+
+      playground.bootstrap(bootstrapOpts, mustSucceed((agentId) => {
+        requestId = playground.zmqAgentBus.agentSnapshotRequest(agentId, options);
+        playground.zmqAgentBus.agentSnapshotRequest(agentId, options, mustCall((err) => {
+          assert.strictEqual(err.code, 409);
+          assert.strictEqual(err.message, 'Snapshot already in progress');
+        }));
+      }), (eventType, agentId, data) => {
+        switch (++events) {
+          case 1:
+            assert.strictEqual(eventType, 'asset-data-packet');
+            if (data.packet.length > 0) {
+              checkSnapshotData(requestId, options, agentId, data.metadata, false);
+              --events;
+            } else {
+              checkSnapshotData(requestId, options, agentId, data.metadata, true);
+            }
+            break;
+          case 2:
+            assert.strictEqual(eventType, 'asset-received');
+            checkSnapshotData(requestId, options, agentId, data, true);
+            resolve();
+        }
+      });
+    });
+  }
+});
+
+
+const config = {
+  commandBindAddr: 'tcp://*:9001',
+  dataBindAddr: 'tcp://*:9002',
+  bulkBindAddr: 'tcp://*:9003',
+  HWM: 0,
+  bulkHWM: 0,
+  commandTimeoutMilliseconds: 5000
+};
+
+
+const playground = new TestPlayground(config);
+await playground.startServer();
+
+for (const { name, test } of tests) {
+  console.log(`heap snapshot ${name}`);
+  await test(playground);
+  await playground.stopClient();
+}
+
+playground.stopServer();

--- a/test/agents/test-zmq-startup-times.mjs
+++ b/test/agents/test-zmq-startup-times.mjs
@@ -1,0 +1,114 @@
+// Flags: --expose-internals
+import { mustSucceed } from '../common/index.mjs';
+import assert from 'node:assert';
+import validators from 'internal/validators';
+import { TestPlayground } from '../common/nsolid-zmq-agent/index.js';
+
+const {
+  validateArray,
+  validateInteger,
+  validateObject,
+  validateUint32,
+} = validators;
+
+
+//  Data has this format:
+//  {
+//   agentId: '67c1a5e7d9b6520045a0f61e5c87c3009fc9f355',
+//   requestId: '3d3604f6-ed11-4e76-91c4-efb5258e96e0',
+//   command: 'startup_times',
+//   recorded: { seconds: 1703094691, nanoseconds: 64236343 },
+//   duration: 0,
+//   interval: 3000,
+//   version: 4,
+//   body: {
+//     bootstrap_complete: [ 0, 17975160 ],
+//     initialized_node: [ 0, 433754 ],
+//     initialized_v8: [ 0, 2678126 ],
+//     loaded_environment: [ 0, 8218223 ],
+//     loop_start: [ 0, 22997344 ],
+//     timeOrigin: [ 0, 0 ]
+//   },
+//   time: 1703094691064,
+//   timeNS: '1703094691064236343'
+// }
+
+function checkStartupTimesData(data, requestId, agentId, additionalTimes = []) {
+  assert.strictEqual(data.requestId, requestId);
+  assert.strictEqual(data.agentId, agentId);
+  assert.strictEqual(data.command, 'startup_times');
+  // From here check at least that all the fields are present
+  validateObject(data.recorded, 'recorded');
+  validateUint32(data.recorded.seconds, 'recorded.seconds');
+  validateUint32(data.recorded.nanoseconds, 'recorded.nanoseconds');
+  validateUint32(data.duration, 'duration');
+  validateUint32(data.interval, 'interval');
+  assert.strictEqual(data.version, 4);
+  validateObject(data.body, 'body');
+  validateInteger(data.time, 'time');
+  // Also the body fields
+  assert.ok(data.body.initialized_node);
+  assert.ok(data.body.initialized_v8);
+  assert.ok(data.body.loaded_environment);
+  assert.ok(data.body.loop_start);
+  assert.ok(data.body.timeOrigin);
+  additionalTimes.forEach((time) => assert.ok(data.body[time]));
+  Object.keys(data.body).forEach((key) => {
+    validateArray(data.body[key], `data.body.${key}`);
+    assert.strictEqual(data.body[key].length, 2);
+    validateUint32(data.body[key][0], `data.body.${key}[0]`);
+    validateUint32(data.body[key][1], `data.body.${key}[1]`);
+  });
+}
+
+const tests = [];
+
+tests.push({
+  name: 'should work with the default values',
+  test: async (playground) => {
+    return new Promise((resolve) => {
+      playground.bootstrap(mustSucceed((agentId) => {
+        const requestId = playground.zmqAgentBus.agentStartupTimesRequest(agentId, mustSucceed((info) => {
+          checkStartupTimesData(info, requestId, agentId);
+          resolve();
+        }));
+      }));
+    });
+  }
+});
+
+tests.push({
+  name: 'should work with the custom times',
+  test: async (playground) => {
+    return new Promise((resolve) => {
+      playground.bootstrap(mustSucceed(async (agentId) => {
+        assert.ok(await playground.client.startupTimes('customTime'));
+        const requestId = playground.zmqAgentBus.agentStartupTimesRequest(agentId, mustSucceed((info) => {
+          checkStartupTimesData(info, requestId, agentId, [ 'customTime' ]);
+          resolve();
+        }));
+      }));
+    });
+  }
+});
+
+const config = {
+  commandBindAddr: 'tcp://*:9001',
+  dataBindAddr: 'tcp://*:9002',
+  bulkBindAddr: 'tcp://*:9003',
+  HWM: 0,
+  bulkHWM: 0,
+  commandTimeoutMilliseconds: 5000
+};
+
+
+const playground = new TestPlayground(config);
+await playground.startServer();
+
+for (const { name, test } of tests) {
+  console.log(`startup times command ${name}`);
+  await test(playground);
+  await playground.stopClient();
+}
+
+playground.stopServer();

--- a/test/agents/test-zmq-tracing.mjs
+++ b/test/agents/test-zmq-tracing.mjs
@@ -1,0 +1,359 @@
+// Flags: --expose-internals
+import { mustCall, mustCallAtLeast, mustSucceed } from '../common/index.mjs';
+import assert from 'node:assert';
+import { threadId } from 'node:worker_threads';
+import validators from 'internal/validators';
+import { TestPlayground } from '../common/nsolid-zmq-agent/index.js';
+
+const {
+  validateArray,
+  validateInteger,
+  validateNumber,
+  validateObject,
+  validateString,
+  validateUint32,
+} = validators;
+
+// Data has this format:
+// {
+//   agentId: '17ef14fe5ca50000ec1ae6ac86506e0035ff3712',
+//   requestId: null,
+//   command: 'tracing',
+//   recorded: { seconds: 1704988827, nanoseconds: 304585184 },
+//   duration: 0,
+//   interval: 3000,
+//   version: 4,
+//   body: {
+//     spans: [
+//       {
+//         id: '35ebb6078569c26c',
+//         parentId: '15ec3a1a54d7d1e9',
+//         traceId: '296826148ce0ab83cd036b8f33f26784',
+//         start: 1704988827220.339,
+//         end: 1704988827222.5215,
+//         kind: 1,
+//         type: 8,
+//         name: 'HTTP GET',
+//         threadId: 0,
+//         status: { message: '', code: 0 },
+//         attributes: {
+//           'http.method': 'GET',
+//           'http.status_code': 200,
+//           'http.status_text': 'OK',
+//           'http.url': 'http://127.0.0.1:42347/'
+//         },
+//         events: []
+//       },
+//       {
+//         id: '15ec3a1a54d7d1e9',
+//         parentId: '0000000000000000',
+//         traceId: '296826148ce0ab83cd036b8f33f26784',
+//         start: 1704988827213.4678,
+//         end: 1704988827224.286,
+//         kind: 2,
+//         type: 4,
+//         name: 'HTTP GET',
+//         threadId: 0,
+//         status: { message: '', code: 0 },
+//         attributes: {
+//           'http.method': 'GET',
+//           'http.status_code': 200,
+//           'http.status_text': 'OK',
+//           'http.url': 'http://127.0.0.1:42347/'
+//         },
+//         events: []
+//       }
+//     ]
+//   },
+//   time: 1704988827305,
+//   timeNS: '1704988827304585184'
+// }
+
+function checkTracingData(tracing, requestId, agentId, threadId) {
+  console.dir(tracing, { depth: null });
+  assert.strictEqual(tracing.requestId, requestId);
+  assert.strictEqual(tracing.agentId, agentId);
+  assert.strictEqual(tracing.command, 'tracing');
+  // From here check at least that all the fields are present
+  validateObject(tracing.recorded, 'recorded');
+  validateUint32(tracing.recorded.seconds, 'recorded.seconds');
+  validateUint32(tracing.recorded.nanoseconds, 'recorded.nanoseconds');
+  validateUint32(tracing.duration, 'duration');
+  validateUint32(tracing.interval, 'interval');
+  assert.strictEqual(tracing.version, 4);
+  validateObject(tracing.body, 'body');
+  validateInteger(tracing.time, 'time');
+  validateArray(tracing.body.spans, 'body.spans');
+}
+
+function validateSpan(span, spanType, threadId) {
+  validateString(span.id, 'span.id');
+  validateString(span.parentId, 'span.parentId');
+  validateString(span.traceId, 'span.traceId');
+  validateNumber(span.start, 'span.start');
+  validateNumber(span.end, 'span.end');
+  assert.strictEqual(span.threadId, threadId);
+  validateObject(span.status, 'span.status');
+  validateObject(span.attributes, 'span.attributes');
+  validateArray(span.events, 'span.events');
+  switch (spanType) {
+    case 'http_server':
+      assert.strictEqual(span.kind, 1);
+      assert.strictEqual(span.type, 8);
+      assert.strictEqual(span.name, 'HTTP GET');
+      assert.strictEqual(span.attributes['http.method'], 'GET');
+      assert.strictEqual(span.attributes['http.status_code'], 200);
+      assert.strictEqual(span.attributes['http.status_text'], 'OK');
+      assert.ok(span.attributes['http.url'].startsWith('http://127.0.0.1:'));
+      break;
+    case 'http_client':
+      assert.strictEqual(span.kind, 2);
+      assert.strictEqual(span.type, 4);
+      assert.strictEqual(span.name, 'HTTP GET');
+      assert.strictEqual(span.attributes['http.method'], 'GET');
+      assert.strictEqual(span.attributes['http.status_code'], 200);
+      assert.strictEqual(span.attributes['http.status_text'], 'OK');
+      assert.ok(span.attributes['http.url'].startsWith('http://127.0.0.1:'));
+      break;
+    case 'dns_lookup':
+      assert.strictEqual(span.kind, 2);
+      assert.strictEqual(span.type, 1);
+      assert.strictEqual(span.name, 'DNS lookup');
+      validateString(span.attributes['dns.address'], 'span.attributes.dns.address');
+      assert.strictEqual(span.attributes['dns.hostname'], 'example.org');
+      assert.strictEqual(span.attributes['dns.op_type'], 0);
+      break;
+    case 'dns_lookup_service':
+      assert.strictEqual(span.kind, 2);
+      assert.strictEqual(span.type, 1);
+      assert.strictEqual(span.name, 'DNS lookup_service');
+      assert.strictEqual(span.attributes['dns.address'], '127.0.0.1');
+      validateString(span.attributes['dns.hostname'], 'span.attributes.dns.hostname');
+      assert.strictEqual(span.attributes['dns.op_type'], 1);
+      assert.strictEqual(span.attributes['dns.port'], 22);
+      break;
+    case 'dns_resolve':
+      assert.strictEqual(span.kind, 2);
+      assert.strictEqual(span.type, 1);
+      assert.strictEqual(span.name, 'DNS resolve');
+      validateArray(span.attributes['dns.address'], 'span.attributes.dns.address');
+      assert.strictEqual(span.attributes['dns.hostname'], 'example.org');
+      assert.strictEqual(span.attributes['dns.op_type'], 2);
+      break;
+    case 'custom':
+      assert.strictEqual(span.kind, 2);
+      assert.strictEqual(span.type, 16);
+      assert.strictEqual(span.name, 'initial_name');
+      assert.strictEqual(span.attributes.a, 1);
+      assert.strictEqual(span.attributes.b, 2);
+      assert.strictEqual(span.attributes.c, 3);
+      assert.strictEqual(span.attributes.d, 4);
+      assert.strictEqual(span.attributes.e, 5);
+      assert.strictEqual(span.events.length, 3);
+      assert.strictEqual(span.events[0].name, 'my_event 1');
+      assert.strictEqual(span.events[1].name, 'my_event 2');
+      assert.strictEqual(span.events[1].attributes.attr1, 'val1');
+      assert.strictEqual(span.events[1].attributes.attr2, 'val2');
+      assert.strictEqual(span.events[2].name, 'exception');
+      assert.strictEqual(span.events[2].attributes['exception.type'], 'Error');
+      assert.strictEqual(span.events[2].attributes['exception.message'], 'my_exception');
+      assert.ok(span.events[2].attributes['exception.stacktrace'].startsWith('Error: my_exception'));
+      break;
+  }
+
+  validateUint32(span.threadId, 'span.threadId');
+  validateObject(span.status, 'span.status');
+  validateObject(span.attributes, 'span.attributes');
+  validateArray(span.events, 'span.events');
+}
+
+const tests = [];
+
+tests.push({
+  name: 'should work for http transactions',
+  test: async (playground) => {
+    return new Promise((resolve) => {
+      let totalSpans = 0;
+      const opts = {
+        opts: { env: { NSOLID_TRACING_ENABLED: 1 } }
+      };
+
+      playground.bootstrap(opts, mustSucceed(async (agentId) => {
+        await playground.client.tracing('http', threadId);
+      }), mustCallAtLeast((eventType, agentId, data) => {
+        console.log(`${eventType}, ${agentId}`);
+        assert.strictEqual(eventType, 'agent-tracing');
+        checkTracingData(data, null, agentId, threadId);
+        const spanTypes = [ 'http_server', 'http_client'];
+        for (const span of data.body.spans) {
+          validateSpan(span, spanTypes[totalSpans], threadId);
+          totalSpans++;
+        }
+        if (totalSpans === 2) {
+          resolve();
+        }
+      }, 1));
+    });
+  }
+});
+
+tests.push({
+  name: 'should work for http transactions on a worker',
+  test: async (playground) => {
+    return new Promise((resolve) => {
+      let wid;
+      let totalSpans = 0;
+      const opts = {
+        args: [ '-w', 1 ],
+        opts: { env: { NSOLID_TRACING_ENABLED: 1 } }
+      };
+
+      playground.bootstrap(opts, mustSucceed(async (agentId) => {
+        const workers = await playground.client.workers();
+        wid = workers[0];
+        await playground.client.tracing('http', wid);
+      }), mustCallAtLeast((eventType, agentId, data) => {
+        console.log(`${eventType}, ${agentId}`);
+        assert.strictEqual(eventType, 'agent-tracing');
+        checkTracingData(data, null, agentId, wid);
+        const spanTypes = [ 'http_server', 'http_client'];
+        for (const span of data.body.spans) {
+          validateSpan(span, spanTypes[totalSpans], wid);
+          totalSpans++;
+        }
+        if (totalSpans === 2) {
+          resolve();
+        }
+      }, 1));
+    });
+  }
+});
+
+tests.push({
+  name: 'should work for dns transactions',
+  test: async (playground) => {
+    return new Promise((resolve) => {
+      let totalSpans = 0;
+      const opts = {
+        opts: { env: { NSOLID_TRACING_ENABLED: 1 } }
+      };
+
+      playground.bootstrap(opts, mustSucceed(async (agentId) => {
+        await playground.client.tracing('dns', threadId);
+      }), mustCallAtLeast((eventType, agentId, data) => {
+        console.log(`${eventType}, ${agentId}`);
+        assert.strictEqual(eventType, 'agent-tracing');
+        checkTracingData(data, null, agentId, threadId);
+        const spanTypes = [ 'dns_lookup', 'dns_lookup_service', 'dns_resolve'];
+        for (const span of data.body.spans) {
+          validateSpan(span, spanTypes[totalSpans], threadId);
+          totalSpans++;
+        }
+        if (totalSpans === 3) {
+          resolve();
+        }
+      }, 1));
+    });
+  }
+});
+
+tests.push({
+  name: 'should work for dns transactions on a worker',
+  test: async (playground) => {
+    return new Promise((resolve) => {
+      let wid;
+      let totalSpans = 0;
+      const opts = {
+        args: [ '-w', 1 ],
+        opts: { env: { NSOLID_TRACING_ENABLED: 1 } }
+      };
+
+      playground.bootstrap(opts, mustSucceed(async (agentId) => {
+        const workers = await playground.client.workers();
+        wid = workers[0];
+        await playground.client.tracing('dns', wid);
+      }), mustCallAtLeast((eventType, agentId, data) => {
+        console.log(`${eventType}, ${agentId}`);
+        assert.strictEqual(eventType, 'agent-tracing');
+        checkTracingData(data, null, agentId, wid);
+        const spanTypes = [ 'dns_lookup', 'dns_lookup_service', 'dns_resolve'];
+        for (const span of data.body.spans) {
+          validateSpan(span, spanTypes[totalSpans], wid);
+          totalSpans++;
+        }
+        if (totalSpans === 3) {
+          resolve();
+        }
+      }, 1));
+    });
+  }
+});
+
+tests.push({
+  name: 'should work for custom traces',
+  test: async (playground) => {
+    return new Promise((resolve) => {
+      const opts = {
+        opts: { env: { NSOLID_TRACING_ENABLED: 1 } }
+      };
+
+      playground.bootstrap(opts, mustSucceed(async (agentId) => {
+        await playground.client.tracing('custom', threadId);
+      }), mustCall((eventType, agentId, data) => {
+        console.log(`${eventType}, ${agentId}`);
+        assert.strictEqual(eventType, 'agent-tracing');
+        checkTracingData(data, null, agentId, threadId);
+        assert.strictEqual(data.body.spans.length, 1);
+        validateSpan(data.body.spans[0], 'custom', threadId);
+        resolve();
+      }));
+    });
+  }
+});
+
+tests.push({
+  name: 'should work for custom traces on a worker',
+  test: async (playground) => {
+    return new Promise((resolve) => {
+      let wid;
+      const opts = {
+        args: [ '-w', 1 ],
+        opts: { env: { NSOLID_TRACING_ENABLED: 1 } }
+      };
+
+      playground.bootstrap(opts, mustSucceed(async (agentId) => {
+        const workers = await playground.client.workers();
+        wid = workers[0];
+        await playground.client.tracing('custom', wid);
+      }), mustCall((eventType, agentId, data) => {
+        console.log(`${eventType}, ${agentId}`);
+        assert.strictEqual(eventType, 'agent-tracing');
+        checkTracingData(data, null, agentId, wid);
+        assert.strictEqual(data.body.spans.length, 1);
+        validateSpan(data.body.spans[0], 'custom', wid);
+        resolve();
+      }));
+    });
+  }
+});
+
+const config = {
+  commandBindAddr: 'tcp://*:9001',
+  dataBindAddr: 'tcp://*:9002',
+  bulkBindAddr: 'tcp://*:9003',
+  HWM: 0,
+  bulkHWM: 0,
+  commandTimeoutMilliseconds: 5000
+};
+
+
+const playground = new TestPlayground(config);
+await playground.startServer();
+
+for (const { name, test } of tests) {
+  console.log(`tracing generation ${name}`);
+  await test(playground);
+  await playground.stopClient();
+}
+
+playground.stopServer();

--- a/test/agents/testcfg.py
+++ b/test/agents/testcfg.py
@@ -1,0 +1,6 @@
+import sys, os
+sys.path.append(os.path.join(os.path.dirname(__file__), '..'))
+import testpy
+
+def GetConfiguration(context, root):
+  return testpy.SimpleTestConfiguration(context, root, 'agents')

--- a/test/common/nsolid-zmq-agent/.gitignore
+++ b/test/common/nsolid-zmq-agent/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/test/common/nsolid-zmq-agent/client.js
+++ b/test/common/nsolid-zmq-agent/client.js
@@ -1,0 +1,146 @@
+'use strict';
+
+const http = require('node:http');
+const { parseArgs } = require('node:util');
+const { isMainThread, parentPort, Worker, threadId } = require('node:worker_threads');
+const nsolid = require('nsolid');
+const { fixturesDir } = require('../fixtures');
+
+const options = {
+  workers: {
+    type: 'string',
+    short: 'w',
+  },
+};
+const args = parseArgs({ options });
+
+const interval = setInterval(() => {
+}, 100);
+
+function execHttpTransaction() {
+  const server = http.createServer((req, res) => {
+    res.writeHead(200, { 'Content-Type': 'text/plain' });
+    res.end('Hello World\n');
+  });
+
+  server.listen(0, () => {
+    const port = server.address().port;
+    const req = http.request({
+      host: '127.0.0.1',
+      port,
+      method: 'GET',
+      path: '/',
+    }, (res) => {
+      res.on('data', () => {
+      });
+      res.on('end', () => {
+        server.close();
+      });
+    });
+    req.end();
+  });
+}
+
+function execDnsTransaction() {
+  const dns = require('node:dns');
+  dns.lookup('example.org', () => {
+    dns.lookupService('127.0.0.1', 22, () => {
+      dns.resolve('example.org', () => {
+      });
+    });
+  });
+}
+
+function execCustomTrace() {
+  console.log('execCustomTrace');
+  const api = require(require.resolve('@opentelemetry/api',
+                                      { paths: [fixturesDir] }));
+  console.log(nsolid.otel.register(api));
+  const tracer = api.trace.getTracer('test');
+  const span = tracer.startSpan('initial_name', { attributes: { a: 1, b: 2 },
+                                                  kind: api.SpanKind.CLIENT });
+  span.setAttributes({ c: 3, d: 4 })
+      .setAttribute('e', 5)
+      .addEvent('my_event 1', Date.now())
+      .addEvent('my_event 2', { attr1: 'val1', attr2: 'val2' }, Date.now());
+  span.recordException(new Error('my_exception'));
+  span.setStatus({ code: api.SpanStatusCode.ERROR, message: 'my_message' });
+  span.end();
+  setTimeout(() => {}, 1000);
+}
+
+function blockFor(duration) {
+  const start = Date.now();
+  while (Date.now() - start < duration);
+}
+
+function handleTrace(msg) {
+  if (msg.type === 'trace') {
+    switch (msg.kind) {
+      case 'http':
+        execHttpTransaction();
+        break;
+      case 'dns':
+        execDnsTransaction();
+        break;
+      case 'custom':
+        execCustomTrace();
+        break;
+    }
+  }
+}
+
+if (isMainThread) {
+  const workers = new Map();
+  process.on('message', (msg) => {
+    if (msg.type === 'block') {
+      if (threadId === msg.threadId) {
+        blockFor(msg.duration);
+      } else {
+        workers.get(msg.threadId).postMessage(msg);
+      }
+    } else if (msg.type === 'config') {
+      process.send({ type: 'config', config: nsolid.config });
+    } else if (msg.type === 'shutdown') {
+      clearInterval(interval);
+      if (!msg.error) {
+        process.exit(msg.code || 0);
+      } else {
+        throw new Error('error');
+      }
+    } else if (msg.type === 'startupTimes') {
+      process.recordStartupTime(msg.name);
+      process.send(msg);
+    } else if (msg.type === 'trace') {
+      if (threadId === msg.threadId) {
+        handleTrace(msg);
+      } else {
+        workers.get(msg.threadId).postMessage(msg);
+      }
+    } else if (msg.type === 'workers') {
+      process.send({ type: 'workers', ids: Array.from(workers.keys()) });
+    }
+  });
+
+  if (args.values.workers) {
+    const NUM_WORKERS = parseInt(args.values.workers, 10);
+    if (!Number.isNaN(NUM_WORKERS)) {
+      for (let i = 0; i < NUM_WORKERS; i++) {
+        const worker = new Worker(__filename);
+        workers.set(worker.threadId, worker);
+      }
+    }
+  }
+} else {
+  parentPort.on('message', (msg) => {
+    console.log('message', msg);
+    switch (msg.type) {
+      case 'block':
+        blockFor(msg.duration);
+        break;
+      case 'trace':
+        handleTrace(msg);
+        break;
+    }
+  });
+}

--- a/test/common/nsolid-zmq-agent/index.js
+++ b/test/common/nsolid-zmq-agent/index.js
@@ -1,0 +1,325 @@
+'use strict';
+
+const common = require('../');
+const assert = require('node:assert');
+const path = require('node:path');
+const ZmqAgentBus = require('./zmqagentbus');
+const { fork } = require('node:child_process');
+
+function checkExitData(data, expected) {
+  assert.strictEqual(data.exit_code, expected.exit_code);
+  assert.strictEqual(data.error, expected.error);
+}
+
+const BootstrapState = {
+  INIT: 0,
+  GOTINFO: 1 << 0,
+  GOTPACKAGES: 1 << 1,
+  GOTMETRICS: 1 << 2,
+};
+
+const State = {
+  INIT: 0,
+  CONNECTED: 1,
+};
+
+const defaultForkOpts = {
+  env: {
+    NSOLID_COMMAND: 9001,
+    NODE_DEBUG_NATIVE: process.env.NODE_DEBUG_NATIVE,
+  },
+  stdio: ['inherit', 'inherit', 'inherit', 'ipc'],
+};
+
+const eventTypes = [
+  'agent-connected',
+  'agent-ping',
+  'agent-info',
+  'agent-metrics',
+  'agent-packages',
+  'agent-startup-times',
+  'agent-tracing',
+  'agent-loop_blocked',
+  'agent-loop_unblocked',
+  'agent-exit',
+  'asset-received',
+  'asset-data-packet',
+  'agent-error',
+];
+
+class TestClient {
+  #child;
+  constructor(args = [], options = {}) {
+    const opts = { ...defaultForkOpts };
+    Object.keys(options).forEach((key) => {
+      opts[key] = { ...opts[key], ...options[key] };
+    });
+    this.#child = fork(path.join(__dirname, 'client.js') + '', args, opts);
+    this.#child.on('exit', (code, signal) => {
+      console.log(`child process exited with code ${code} and signal ${signal}`);
+    });
+  }
+
+  async block(threadId, duration) {
+    return new Promise((resolve) => {
+      if (this.#child) {
+        this.#child.send({ type: 'block', threadId, duration }, () => {
+          resolve();
+        });
+      } else {
+        resolve();
+      }
+    });
+  }
+
+  async config() {
+    return new Promise((resolve) => {
+      if (this.#child) {
+        this.#child.send({ type: 'config' });
+        this.#child.once('message', common.mustCall((msg) => {
+          if (msg.type === 'config') {
+            resolve(msg.config);
+          }
+        }));
+      } else {
+        resolve(null);
+      }
+    });
+  }
+
+  async exception(msg) {
+    return new Promise((resolve) => {
+      if (this.#child) {
+        this.#child.send({ type: 'shutdown', error: msg });
+        this.#child.once('exit', common.mustCall((code, signal) => {
+          this.#child = null;
+          resolve({ code, signal });
+        }));
+      } else {
+        resolve();
+      }
+    });
+  }
+
+  async kill(signal) {
+    return new Promise((resolve) => {
+      let done = false;
+      if (this.#child) {
+        this.#child.once('exit', common.mustCall((code, signal) => {
+          this.#child = null;
+          done = true;
+          resolve({ code, signal });
+        }));
+        // This should not be needed but for some reason the child is not always
+        // killed on the first attempt.
+        const interval = setInterval(() => {
+          if (!done) {
+            this.#child.kill();
+          } else {
+            clearInterval(interval);
+          }
+        }, 100);
+      } else {
+        resolve();
+      }
+    });
+  }
+
+  async shutdown(code) {
+    return new Promise((resolve) => {
+      if (this.#child) {
+        this.#child.send({ type: 'shutdown', code });
+        this.#child.once('exit', common.mustCall((code, signal) => {
+          this.#child = null;
+          resolve({ code, signal });
+        }));
+      } else {
+        resolve();
+      }
+    });
+  }
+
+  async startupTimes(name) {
+    return new Promise((resolve) => {
+      if (this.#child) {
+        this.#child.send({ type: 'startupTimes', name });
+        this.#child.on('message', common.mustCall((msg) => {
+          if (msg.type === 'startupTimes' && msg.name === name) {
+            resolve(true);
+          }
+        }));
+      } else {
+        resolve(false);
+      }
+    });
+  }
+
+  async tracing(kind, threadId) {
+    return new Promise((resolve) => {
+      if (this.#child) {
+        this.#child.send({ type: 'trace', kind, threadId }, () => {
+          resolve();
+        });
+      } else {
+        resolve();
+      }
+    });
+  }
+
+  async workers() {
+    return new Promise((resolve) => {
+      if (this.#child) {
+        this.#child.send({ type: 'workers' });
+        this.#child.on('message', common.mustCall((msg) => {
+          if (msg.type === 'workers') {
+            resolve(msg.ids);
+          }
+        }));
+      } else {
+        resolve([]);
+      }
+    });
+  }
+
+  child() {
+    return this.#child;
+  }
+}
+
+class TestPlayground {
+  client;
+  #state;
+  #bootstrapState;
+  constructor(config) {
+    this.zmqAgentBus = new ZmqAgentBus(config);
+    this.#state = State.INIT;
+    this.#bootstrapState = BootstrapState.INIT;
+    this.client = null;
+  }
+
+  async startServer() {
+    return new Promise((resolve) => {
+      this.zmqAgentBus.start((err) => {
+        assert.ifError(err);
+        resolve();
+      });
+    });
+  }
+
+  stopServer() {
+    this.zmqAgentBus.shutdown();
+  }
+
+  bootstrap(options, done, next) {
+    if (typeof options === 'function') {
+      next = done;
+      done = options;
+      options = {};
+    }
+
+    options = options || {};
+
+    let id;
+    let events = 0;
+    eventTypes.forEach((eventType) => {
+      this.zmqAgentBus.on(eventType, (agentId, data) => {
+        console.log(`[${events}] ${eventType}, ${agentId}`);
+        try {
+          if (!id) {
+            id = agentId;
+          } else {
+            assert.strictEqual(id, agentId);
+          }
+
+          switch (++events) {
+            case 1:
+              assert.strictEqual(eventType, 'agent-connected');
+              this.#state = State.CONNECTED;
+              break;
+            case 2:
+              this.#checkInitialSequence(eventType, data);
+              // The runtime may send metrics before the initial sequence is sent.
+              if (eventType === 'agent-metrics') {
+                --events;
+              }
+              break;
+            case 3:
+              this.#checkInitialSequence(eventType, data);
+              break;
+            case 4:
+              this.#checkInitialSequence(eventType, data);
+              assert.ok(this.#bootstrapState &&
+                        (BootstrapState.GOTINFO | BootstrapState.GOTPACKAGES | BootstrapState.GOTMETRICS));
+              done(null, agentId);
+              break;
+            default:
+              if (next)
+                next(eventType, agentId, data);
+          }
+        } catch (err) {
+          this.stopClient();
+          done(err);
+        }
+      });
+    });
+
+    assert.ok(!this.#clientAlive());
+    const opts = { ...options.opts };
+    opts.env = { NSOLID_PUBKEY: this.zmqAgentBus.server.keyPair.public, ...opts.env };
+    this.client = new TestClient(options.args, opts);
+  }
+
+  async stopClient() {
+    return new Promise((resolve) => {
+      let calls = 0;
+      this.#unsubscribeAll();
+      if (this.#clientAlive()) {
+        this.zmqAgentBus.on('agent-exit', common.mustCall((agentId, data) => {
+          checkExitData(data, { exit_code: 0, error: null });
+          this.#unsubscribeAll();
+          if (++calls === 2) {
+            resolve();
+          }
+        }));
+        this.client.shutdown(0).then((exit) => {
+          assert.strictEqual(exit.code, 0);
+          assert.strictEqual(exit.signal, null);
+          if (++calls === 2) {
+            resolve();
+          }
+        });
+      } else {
+        resolve();
+      }
+    });
+  }
+
+  #checkInitialSequence(eventType, data) {
+    if (eventType === 'agent-info') {
+      this.#bootstrapState |= BootstrapState.GOTINFO;
+      // parse info data
+    } else if (eventType === 'agent-packages') {
+      this.#bootstrapState |= BootstrapState.GOTPACKAGES;
+      // parse packages data
+    } else if (eventType === 'agent-metrics') {
+      this.#bootstrapState |= BootstrapState.GOTMETRICS;
+      // parse metrics data
+    }
+  }
+
+  #clientAlive() {
+    return this.client && this.client.child();
+  }
+
+  #unsubscribeAll() {
+    eventTypes.forEach((eventType) => {
+      this.zmqAgentBus.removeAllListeners(eventType);
+    });
+  }
+
+}
+
+module.exports = {
+  checkExitData,
+  TestPlayground,
+};

--- a/test/common/nsolid-zmq-agent/server.js
+++ b/test/common/nsolid-zmq-agent/server.js
@@ -1,0 +1,137 @@
+'use strict';
+
+const util = require('node:util');
+const debuglog = util.debuglog('test');
+const zmqzap = require('zmq-zap');
+const zap = new zmqzap.ZAP();
+const ZMQBindSocket = require('./socket');
+const zmq = require('zeromq');
+
+zap.use(new zmqzap.CurveMechanism(function(data, callback) {
+  // Authorize all ZeroMQ socket connections.
+  callback(null, true);
+}));
+
+// Create a version of a function which will only be called once
+function onlyCallOnce(fn) {
+  let called = false;
+
+  return function onlyCalledOnce() {
+    if (called) return;
+    called = true;
+
+    return fn.apply(null, arguments);
+  };
+}
+
+class ZmqServer {
+  constructor(config) {
+    debuglog('ZeroMQServer constructor with config', config);
+    this.started = false;
+    this.config = config;
+    this.keyPair = zmq.curveKeypair();
+  }
+
+  start(commandHandler, dataHandler, bulkHandler, cb) {
+    if (this.started) {
+      return cb(new Error('ZeroMQ server already started'));
+    }
+    debuglog('launching ZeroMQ Agent server');
+    debuglog(`ZeroMQ data channel url: ${this.config.dataBindAddr}`);
+    debuglog(`ZeroMQ bulk channel url: ${this.config.bulkBindAddr}`);
+    debuglog(`ZeroMQ command channel url: ${this.config.commandBindAddr}`);
+
+    const reply = onlyCallOnce(cb);
+    let boundCount = 0;
+    const socksBound = (err) => {
+      if (err) reply(err);
+      if (++boundCount === 3) reply();
+    };
+
+    this.data = new ZMQBindSocket({
+      name: 'data',
+      bindUrl: this.config.dataBindAddr,
+      privateKey: this.keyPair.secret,
+      hwm: this.config.HWM,
+      type: 'pull',
+      bindCb: socksBound,
+      messageHandler: dataHandler,
+      server: this,
+    });
+
+    this.bulk = new ZMQBindSocket({
+      name: 'bulk',
+      bindUrl: this.config.bulkBindAddr,
+      privateKey: this.keyPair.secret,
+      hwm: this.config.bulkHWM,
+      type: 'pull',
+      bindCb: socksBound,
+      messageHandler: bulkHandler,
+      server: this,
+    });
+
+    this.command = new ZMQBindSocket({
+      name: 'command',
+      bindUrl: this.config.commandBindAddr,
+      privateKey: this.keyPair.secret,
+      hwm: this.config.HWM,
+      type: 'xpub',
+      bindCb: socksBound,
+      messageHandler: commandHandler,
+      server: this,
+    });
+
+    this.started = true;
+  }
+
+  // TODO debounce these over a small time window?
+  send(message) {
+    if (message.id) {
+      this.sendToAgent(message);
+    } else {
+      this.broadcast(message);
+    }
+  }
+
+  sendToAgent(message) {
+    if (!this.command.socket) {
+      debuglog('Message could not be sent after socket closed', message);
+    }
+
+    debuglog('sending agent command message', message);
+    const id = message.id;
+    message = JSON.stringify(message);
+    this.command.socket.send([`id:${id}`, message]);
+  }
+
+  broadcast(message) {
+    if (!this.command.socket) {
+      debuglog('Message could not be sent after socket closed', message);
+    }
+
+    debuglog('sending broadcast command message', message);
+    message = JSON.stringify(message);
+    this.command.socket.send(['broadcast', message]);
+  }
+
+  shutdown() {
+    if (!this.started) {
+      return;
+    }
+    debuglog('Shutting down ZeroMQ');
+
+    closeCatching('data', this.data);
+    closeCatching('bulk', this.bulk);
+    closeCatching('command', this.command);
+  }
+}
+
+function closeCatching(name, socket) {
+  try {
+    socket.close();
+  } catch (err) {
+    console.info(err, `error closing zmq socket ${name}`);
+  }
+}
+
+module.exports = ZmqServer;

--- a/test/common/nsolid-zmq-agent/socket.js
+++ b/test/common/nsolid-zmq-agent/socket.js
@@ -1,0 +1,86 @@
+'use strict';
+
+const util = require('node:util');
+const debuglog = util.debuglog('test');
+const zmq = require('zeromq');
+
+class ZMQBindSocket {
+  constructor(params) {
+    this.bindUrl = params.bindUrl;
+    this.name = params.name;
+    this.type = params.type;
+    this.bindCb = params.bindCb;
+    this.messageHandler = params.messageHandler;
+    this.server = params.server;
+
+    if (!/:\/\//.test(this.bindUrl)) {
+      this.bindUrl = 'tcp://' + this.bindUrl;
+    }
+
+    if (/^(sub|push)$/.test(this.type)) {
+      console.error(`Use ZMQRemoteSocket for ${this.type} sockets (${params.bindUrl || params.remoteUrl})`);
+      throw new Error('let\'s crash');
+    }
+
+    this.socket = zmq.socket(params.type);
+
+    this.socket.monitor(500, 0);
+    this.socket.setsockopt(zmq.ZMQ_SNDHWM, params.hwm);
+    this.socket.setsockopt(zmq.ZMQ_IPV6, 1);
+    this.socket.setsockopt(zmq.ZMQ_BACKLOG, 2048);
+
+    // Make every subscription fire a message even if it's redundant.  Without
+    // this, agents trying to get configuration at the same time will fail.
+    if (this.type === 'xpub') {
+      this.socket.setsockopt(zmq.ZMQ_XPUB_VERBOSE, 1);
+    }
+
+    this.socket.curve_server = 1;
+    this.socket.curve_secretkey = params.privateKey;
+
+    this.socket.on('bind', () => {
+      debuglog(`${this.type} socket bound to ${this.bindUrl}`);
+      if (this.bindCb) {
+        this.bindCb();
+      }
+    });
+    this.socket.on('bind_error', (event, endpoint, ex) => this.exitOnError(ex || event));
+
+    this.socket.on('message', this.messageHandler);
+    this.socket.bind(this.bindUrl);
+
+    this.socket.on('accept', () => debuglog(`${this.type} socket accepted a remote connection to ${this.bindUrl}`));
+  }
+
+  exitOnError(err) {
+    if (!(err instanceof Error)) err = new Error(`zmq bind error: ${err}`);
+    console.error(err, `Couldn't bind ${this.type} channel socket to ${this.bindUrl}`);
+    if (this.bindCb) {
+      this.bindCb(err);
+    } else {
+      throw new Error('let\'s crash');
+    }
+  }
+
+  close() {
+    // Already closed
+    if (!this.socket) return;
+
+    this.socket.setsockopt(zmq.ZMQ_LINGER, 0);
+    // If we bound to a wildcard, ZMQ doesn't actually allow you to unbind from
+    // that same string, so you must ask it for what it believes the bind
+    // address is.  Who even knows why.
+    const unbindUrl = this.socket.getsockopt(zmq.ZMQ_LAST_ENDPOINT);
+    this.socket.unbind(unbindUrl, (err) => {
+      if (err) {
+        console.error(`Error while unbinding ZMQ socket: ${err.stack}`);
+      }
+      this.socket.removeAllListeners();
+      this.socket.unmonitor();
+      this.socket.close();
+      this.socket = null;
+    });
+  }
+}
+
+module.exports = ZMQBindSocket;

--- a/test/common/nsolid-zmq-agent/zmqagentbus.js
+++ b/test/common/nsolid-zmq-agent/zmqagentbus.js
@@ -1,0 +1,444 @@
+'use strict';
+
+const { randomUUID } = require('node:crypto');
+const util = require('node:util');
+const debuglog = util.debuglog('test');
+const EventEmitter = require('events').EventEmitter;
+const ZmqServer = require('./server');
+
+const defaultProfileSettings = {
+  duration: 5000, // milliseconds
+  threadId: 0,
+  metadata: {
+    reason: 'unspecified',
+  },
+};
+
+const defaultSnapshotSettings = {
+  threadId: 0,
+  metadata: {
+    reason: 'unspecified',
+  },
+};
+
+class ZmqAgentBus extends EventEmitter {
+  constructor(serverConfig) {
+    super();
+    this.serverConfig = serverConfig;
+    this.server = new ZmqServer(serverConfig);
+  }
+
+
+  // *********
+  // Implement the AgentBus interface
+  //
+
+  /**
+   * XPing an agent
+   * This tells the agent to hangup and reconnect
+   * @param {agentId} id the Agent id
+   * @param {Function} callback function(err, body)
+   * @returns {string} requestId
+   */
+  agentXPingRequest(id, callback) {
+    const args = { restart: true };
+    const requestId = this._sendCB({ id: id, command: 'xping', args }, callback);
+    debuglog('ZmqAgentBus:agentXPingRequest', requestId);
+    return requestId;
+  }
+
+  /**
+   * Ping an agent
+   * @param {agentId} id the Agent id
+   * @param {Function} callback function(err, body)
+   * @returns {string} requestId
+   */
+  agentPingRequest(id, callback) {
+    const requestId = this._sendCB({ id: id, command: 'ping' }, callback);
+    debuglog('ZmqAgentBus:agentPingRequest', requestId);
+    return requestId;
+  }
+
+  /**
+   * Broadcast a ping to all agents
+   * @returns {string} requestId
+   */
+  broadcastPingRequest() {
+    const requestId = this._send({ command: 'ping' });
+    debuglog(`ZmqAgentBus:broadcastPingRequest ${requestId}`);
+    // NB: this will only last until 2x timeout after the last reply
+    // then it will be cleaned up
+    this.on(`data:${requestId}`, (data) => {
+      this.emit('agent-ping', null, data);
+    });
+    // NOTE: no error event because this is too niche and is only really
+    // for testing and debugging
+    return requestId;
+  }
+  // NB: No other commands are getting broadcast equivalents even though this zmq
+  // protocol supports it. Just not useful enough. Use an Agent pool and a loop.
+
+  /**
+   * Request agent info from a connected agent
+   * @param {agentId} id the Agent id
+   * @param {Function} callback function(err, body)
+   * @returns {string} requestId
+   */
+  agentInfoRequest(id, callback) {
+    const requestId = this._sendCB({ id: id, command: 'info' }, callback);
+    debuglog('ZmqAgentBus:agentInfoRequest', requestId);
+    return requestId;
+  }
+
+  /**
+   * Request agent metrics from a connected agent
+   * @param {agentId} id the Agent id
+   * @param {Function} callback function(err, body)
+   * @returns {string} requestId
+   */
+  agentMetricsRequest(id, callback) {
+    const requestId = this._sendCB({ id: id, command: 'metrics' }, callback);
+    debuglog('ZmqAgentBus:agentMetricsRequest', requestId);
+    return requestId;
+  }
+
+  /**
+   * Request package list from a connected agent
+   * @param {agentId} id the Agent id
+   * @param {Function} callback function(err, body)
+   * @returns {string} requestId
+   */
+  agentPackagesRequest(id, callback) {
+    const requestId = this._sendCB({ id: id, command: 'packages' }, callback);
+    debuglog('ZmqAgentBus:agentPackagesRequest', requestId);
+    return requestId;
+  }
+
+  /**
+   * Request agent startup times object from a connected agent
+   * @param {agentId} id the Agent id
+   * @param {Function} callback function(err, body)
+   * @returns {string} requestId
+   */
+  agentStartupTimesRequest(id, callback) {
+    const requestId = this._sendCB({ id: id, command: 'startup_times' }, callback);
+    debuglog('ZmqAgentBus:agentStartupTimesRequest', requestId);
+    return requestId;
+  }
+
+  // TODO tracing
+
+  /**
+   * Send reconfigure command to a connected agent
+   * @param {agentId} id the Agent id
+   * @param {object} config the configuration object
+   * @param {Function} callback function(err, body)
+   * @returns {string} requestId
+   */
+  agentReconfigureRequest(id, config, callback) {
+    const requestId = this._sendCB({ id: id, command: 'reconfigure', args: config }, callback);
+    debuglog('ZmqAgentBus:agentReconfigureRequest', requestId);
+    return requestId;
+  }
+
+  /**
+   * Send profile start to a connected agent
+   * @param {agentId} id the Agent id
+   * @param {object} profileSettings profile profile command settings object
+   * @returns {string} requestId
+   */
+  agentProfileStart(id, profileSettings, callback) {
+    const args = profileSettings === null ? profileSettings : { ...defaultProfileSettings, ...profileSettings };
+    const requestId = this._sendCB({ id: id, command: 'profile', args }, callback);
+    debuglog('ZmqAgentBus:agentProfileStart', requestId);
+    return requestId;
+  }
+
+  // /**
+  //  * Send profile stop to a connected agent
+  //  * @param {agentId} id the Agent id
+  //  * @returns {string} requestId
+  //  */
+  // agentProfileStop(id) {
+  //   // TODO
+  // }
+
+  /**
+   * Send heap snapshot command to a connected agent
+   * @param {agentId} id the Agent id
+   * @param {object} settings heap snapshot command settings object
+   * @returns {string} requestId
+   */
+  agentSnapshotRequest(id, settings, callback) {
+    const args = settings === null ? settings : { ...defaultSnapshotSettings, ...settings };
+    const requestId = this._sendCB({ id: id, command: 'snapshot', args }, callback);
+    debuglog('ZmqAgentBus:agentSnapshotRequest', requestId);
+    return requestId;
+  }
+
+  // TODO send generic command to agent
+
+  start(cb) {
+    this.server.start(
+      this._handleCommand.bind(this),
+      this._handleMessage.bind(this),
+      this._handleBulkMessage.bind(this),
+      cb,
+    );
+  }
+
+  shutdown() {
+    this.server.shutdown();
+  }
+
+  // ****************
+  // Translate the AgentBus interface into ZeroMQ messages
+  //
+
+  _handshakeAgent(agentConfigTopicString, agentId) {
+    // An agent connected and subscribed to configuration-<agentId>
+    // it needs to be sent the rest of the configuration
+    const payload = {
+      config: { sockets: this.serverConfig },
+    };
+    debuglog('Sending handshake to agent', agentId);
+    debuglog([agentConfigTopicString, JSON.stringify(payload)]);
+    this._rawSend([agentConfigTopicString, JSON.stringify(payload)]);
+    // Emit agent-connected event (soon)
+    setImmediate(() => this.emit('agent-connected', agentId));
+  }
+
+  _handleCommand(message) {
+    const isSub = message[0];
+    const subscription = message.slice(1).toString();
+
+    // An incoming command on the command channel
+    debuglog(`Handling agent ${isSub ? '' : 'UN'}subscription to ${message.toString('utf8')}`);
+    // An XPUB message is a subscription.  The first byte in the buffer will be
+    // 1 for subscribe and 0 for unsubscribe.  The remaining bytes are the
+    // subscription string.
+    if (isSub && /^configuration/.test(subscription)) {
+      const matchedAgentId = subscription.match(/^configuration-(.*)/);
+      if (matchedAgentId) {
+        // An agent connected and subscribed to configuration-<agentId>
+        // for its own agentId in order to receive non-broadcast configuration
+        // messages
+
+        // the agent does this upon startup, and usually only connects on one
+        // channel because it is started with incomplete configuration and
+        // is expecting a handshake reply with the rest of the configuration
+        const agentId = matchedAgentId[1];
+        this._handshakeAgent(subscription, agentId);
+      }
+    }
+    // TODO other subscriptions types?
+  }
+
+  _handleMessage(rawMessage) {
+    // An incoming message on the data channel
+    // debuglog(`Handling DATA message: ${rawMessage.toString('utf8').substr(0, 100)}...`)
+    debuglog(`Handling DATA message: ${rawMessage.toString('utf8')}`);
+    let message;
+    try {
+      message = JSON.parse(rawMessage);
+    } catch (err) {
+      // No requestId available on parse error, so no real channel to emit to?
+      // this.emit(`error:${message.requestId}`, new Error('ZeroMQ data message parse error'))
+      // TODO what to do here?
+      console.log('ZeroMQ data message parse error');
+      console.log(err);
+      return;
+    }
+
+    message.command = message.command || '_';
+    debuglog(`Handling message: command: ${message.command} requestId: ${message.requestId} agentId: ${message.agentId}`);
+
+    fixTimeProperties(message);
+
+    if (message.requestId == null) {
+      debuglog(`broadcasting unsolicited <${message.command}> message from <${message.agentId || 'broadcast'}>`);
+      this.emit(`agent-${message.command}`, message.agentId, message);
+    }
+
+    if (message.error) {
+      const err = message.error.message || 'No command response from agent.';
+      const e = new Error(err);
+      e.code = message.error.code;
+      this.emit(`error:${message.requestId}`, e);
+      return;
+    }
+
+    this.emit(`data:${message.requestId}`, message);
+    if (message.complete) {
+      this.emit(`end:${message.requestId}`);
+    }
+  }
+
+  _handleBulkMessage(rawMessage, data) {
+    // An incoming data envelope on the bulk channel
+    let envelope;
+    try {
+      envelope = JSON.parse(rawMessage);
+    } catch (err) {
+      debuglog('ZeroMQ bulk envelope parse error -- unable to extract requestId');
+      console.log(err);
+      this.emit(`error:${envelope.requestId}`, new Error('ZeroMQ bulk envelope parse error'));
+      return;
+    }
+    // Example envelope:
+    // {"agentId":"2b76be9d590a15008b4db11ff42221004d5eb8bf",
+    //  "requestId": "8b4a8f82-5a31-4782-91bb-6f3ac65900f3",
+    //  "command":"snapshot",
+    //  "duration":514,
+    //  "metadata":{"reason":"unspecified"},
+    //  "complete":true,
+    //  "threadId":0,
+    // "version":4}
+    envelope.bulkId = envelope.requestId;
+    debuglog(`incoming BULK packet for ${envelope.command} ${envelope.requestId}`);
+    this.emit('asset-data-packet', envelope.agentId, { metadata: envelope, packet: data });
+    if (envelope.complete) {
+      // Delay just a tad to give the asset a bit of time to breathe
+      setImmediate(() => { this.emit('asset-received', envelope.agentId, envelope); });
+    }
+  }
+
+  _rawSend(messageTuple = []) {
+    if (messageTuple.length !== 2 ||
+      typeof messageTuple[0] !== 'string' ||
+      typeof messageTuple[1] !== 'string') {
+      throw new Error('Invalid message to _rawSend');
+    }
+    this.server.command.socket.send(messageTuple);
+  }
+
+  /**
+   * Send a command to an N|Solid Agent over ZeroMQ.
+   * @params {object} message
+   * @params {string} message.id - The ID of the agent.
+   * @params {string} message.command - The command type.
+   * @params {string} message.requestId - The request ID to use to associate
+   * responses.
+   * @params {object} [message.args] - Optional key-value pairs to send as
+   * arguments to the command.
+   * @params {object} [message.filter] - Optional key-value pairs for the
+   * agent to filter on to determine whether or not to process the message.
+   */
+  _send(message) {
+    const defaults = { requestId: randomUUID(), version: 4 };
+    message = { ...defaults, ...message };
+    debuglog(`Sending command message: ${message.requestId}`);
+    const self = this;
+
+    const timeout = this.serverConfig.commandTimeoutMilliseconds || 10000;
+
+    if (!message.command) {
+      // Can't have any listeners till this method returns the requestId,
+      // so emit the error later
+      setImmediate(() => {
+        this.emit(`error:${message.requestId}`, new Error('Command required.'));
+      });
+      return message.requestId;
+    }
+
+    const start = Date.now();
+    debuglog(`ZmqAgentBus: dispatching ${message.command} to ${message.id || 'broadcast'}`);
+    this.server.send(message);
+
+    const cancelTimer = setTimeout(() => {
+      const { id, requestId, command, filter, version } = message;
+      const cancelMessage = { id, requestId, command, filter, version, cancel: true };
+
+      this.server.send(cancelMessage);
+
+      this.emit(`error:${message.requestId}`, new Error('Command timeout.'));
+      debuglog(`Sending cancel command for ${message.command} to ${message.id || 'broadcast'} with requestId ${message.requestId}.`);
+      debuglog(`Command timeout (${timeout} ms) for ${message.command} to ${message.id || 'broadcast'} with requestId ${message.requestId}.`);
+    }, timeout);
+    cancelTimer.unref(); // Don't prevent shutdown
+
+    // whenever we receive data, defer the cleanup timer and prevent the cancel timer
+    this.on(`data:${message.requestId}`, () => {
+      debuglog(`Command ${message.command} to ${message.id || 'broadcast'} with requestId ${message.requestId} finished after ${Date.now() - start} ms`);
+      clearTimeout(cancelTimer);
+      deferCleanup();
+    });
+    // If we receive an error, prevent the cancel timer
+    this.once(`error:${message.requestId}`, (err) => {
+      debuglog(`Command ${message.command} to ${message.id || 'broadcast'} with requestId ${message.requestId} errored after ${Date.now() - start} ms -- ${err}`);
+      clearTimeout(cancelTimer);
+    });
+
+    let cleanupTimer = null;
+
+    function deferCleanup() {
+      if (cleanupTimer !== null)
+        clearTimeout(cleanupTimer);
+      cleanupTimer = setTimeout(cleanup, timeout * 2);
+      cleanupTimer.unref(); // Don't prevent shutdown
+      return cleanupTimer;
+    }
+
+    // Automatically cleanup after timeout * 2, but allow deferral
+    cleanupTimer = deferCleanup();
+
+    // This will also clean up any listeners added elsewhere
+    function cleanup() {
+      debuglog(`Cleaning up listeners for zmq request: ${message.requestId}.`);
+      self.removeAllListeners(`data:${message.requestId}`);
+      self.removeAllListeners(`error:${message.requestId}`);
+    }
+
+    return message.requestId;
+  }
+
+  /**
+   * Like send(message) but using a callback instead of events.
+   * The callback is optional.
+   *
+   * This method can only be used with messages that respond with a single
+   * data response, so SHOULD NOT be used with broadcast commands or commands
+   * that send more than a single data response.
+   */
+  _sendCB(message, cb) {
+    const requestId = this._send(message);
+
+    this.once(`data:${requestId}`, (data) => finishUp(null, data));
+    this.once(`error:${requestId}`, (err) => finishUp(err));
+
+    function finishUp(err, data) {
+      if (cb == null) return;
+      if (err) cb(err);
+      else cb(null, data);
+      // Reset cb to null to prevent double callback
+      // this could only happen if data and error both come back simultaneously
+      debuglog('ZmqAgentBus: _sendCB callback called');
+      cb = null;
+    }
+
+    return requestId;
+  }
+}
+
+// Convert agents `time: {seconds: nanoseconds:}` into usable things.
+// Note both `time` properties are strings, and nanoseconds is left-zero-padded.
+function fixTimeProperties(object) {
+  // Leave early unless a number of constraints hold
+  if (object.recorded == null) return;
+
+  const recorded = object.recorded;
+  if (recorded.seconds == null) return;
+  if (recorded.nanoseconds == null) return;
+
+  // Get the numeric values of the properties
+  const seconds = parseInt(recorded.seconds, 10);
+  const nanoseconds = parseInt(recorded.nanoseconds, 10);
+
+  // Final chance to give up
+  if (!Number.isInteger(seconds) || !Number.isInteger(nanoseconds)) return;
+
+  object.time = Math.round(seconds * 1000 + nanoseconds / 1000000);
+  object.timeNS = `${recorded.seconds}${('000000000' + recorded.nanoseconds).slice(-9)}`;
+}
+
+module.exports = ZmqAgentBus;


### PR DESCRIPTION
Added a `TestPlayground` helper class in `test/common/nsolid-zmq-agent` to help us emulate scenarios.
First batch of tests covering:
- Basic startup and exit.
- `info` command.
- `metrics` command.
- `packages` command.
- `ping` command.
- `profile` command.
- `reconfigure` command.
- `snapshot` command.
- `startup-times` command.

Creating these tests uncovered some unhandled corner cases and issues in `ZmqAgent` which have been addressed.

Added a couple of new targets in the Makefile: `test-agents-prereqs` and `test-agents-prereqs-clean`, to help us setting up the environment.

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
