### PR TITLE
agents: all string metrics in zmq must be escaped

### DIFF
--- a/agents/zmq/src/zmq_agent.cc
+++ b/agents/zmq/src/zmq_agent.cc
@@ -171,7 +171,7 @@ const char PROCESS_METRICS_MSG[] = "{"
   NSOLID_PROCESS_METRICS_DOUBLE(V)
 #undef V
 #define V(Type, CName, JSName, MType) \
-  ",\""#JSName"\":\"%s\""
+  ",\""#JSName"\":%s"
   NSOLID_PROCESS_METRICS_STRINGS(V)
 #undef V
   "}";
@@ -190,7 +190,7 @@ const char THREAD_METRICS_MSG[] = "{"
   NSOLID_ENV_METRICS_DOUBLE(V)
 #undef V
 #define V(Type, CName, JSName, MType) \
-  ",\""#JSName"\":\"%s\""
+  ",\""#JSName"\":%s"
   NSOLID_ENV_METRICS_STRINGS(V)
 #undef V
   "}";
@@ -917,7 +917,7 @@ void ZmqAgent::got_env_metrics(const ThreadMetrics::MetricsStor& stor) {
 NSOLID_PROCESS_METRICS_NUMBERS(V)
 #undef V
 #define V(Type, CName, JSName, MType) \
-            , proc_stor.CName.c_str()
+            , json(proc_stor.CName).dump().c_str()
 NSOLID_PROCESS_METRICS_STRINGS(V)
 #undef V
 );
@@ -935,7 +935,7 @@ NSOLID_PROCESS_METRICS_STRINGS(V)
 NSOLID_ENV_METRICS_NUMBERS(V)
 #undef V
 #define V(Type, CName, JSName, MType) \
-            , it->CName.c_str()
+            , json(it->CName.c_str()).dump().c_str()
 NSOLID_ENV_METRICS_STRINGS(V)
 #undef V
 );

--- a/test/common/nsolid-zmq-agent/client.js
+++ b/test/common/nsolid-zmq-agent/client.js
@@ -111,6 +111,17 @@ if (isMainThread) {
     } else if (msg.type === 'startupTimes') {
       process.recordStartupTime(msg.name);
       process.send(msg);
+    } else if (msg.type === 'threadName') {
+      if (threadId === msg.threadId) {
+        nsolid.setThreadName(msg.name);
+        process.send(msg);
+      } else {
+        const worker = workers.get(msg.threadId);
+        worker.once('message', (msg) => {
+          process.send(msg);
+        });
+        worker.postMessage(msg);
+      }
     } else if (msg.type === 'trace') {
       if (threadId === msg.threadId) {
         handleTrace(msg);
@@ -137,6 +148,10 @@ if (isMainThread) {
     switch (msg.type) {
       case 'block':
         blockFor(msg.duration);
+        break;
+      case 'threadName':
+        nsolid.setThreadName(msg.name);
+        parentPort.postMessage(msg);
         break;
       case 'trace':
         handleTrace(msg);

--- a/test/common/nsolid-zmq-agent/index.js
+++ b/test/common/nsolid-zmq-agent/index.js
@@ -143,8 +143,23 @@ class TestClient {
     return new Promise((resolve) => {
       if (this.#child) {
         this.#child.send({ type: 'startupTimes', name });
-        this.#child.on('message', common.mustCall((msg) => {
+        this.#child.once('message', common.mustCall((msg) => {
           if (msg.type === 'startupTimes' && msg.name === name) {
+            resolve(true);
+          }
+        }));
+      } else {
+        resolve(false);
+      }
+    });
+  }
+
+  async threadName(threadId, name) {
+    return new Promise((resolve) => {
+      if (this.#child) {
+        this.#child.send({ type: 'threadName', threadId, name });
+        this.#child.once('message', common.mustCall((msg) => {
+          if (msg.type === 'threadName' && msg.threadId === threadId) {
             resolve(true);
           }
         }));
@@ -170,7 +185,7 @@ class TestClient {
     return new Promise((resolve) => {
       if (this.#child) {
         this.#child.send({ type: 'workers' });
-        this.#child.on('message', common.mustCall((msg) => {
+        this.#child.once('message', common.mustCall((msg) => {
           if (msg.type === 'workers') {
             resolve(msg.ids);
           }


### PR DESCRIPTION
Improve zmq test suite by allowing setting the `threadName` in the `TestClient` and add a test for the current fix.
