### PR TITLE
agents: fix in-progress profile on exit

### DIFF
--- a/agents/zmq/src/zmq_agent.cc
+++ b/agents/zmq/src/zmq_agent.cc
@@ -2205,13 +2205,6 @@ std::string ZmqAgent::got_cpu_profile(int status,
     last_main_profile_ = req_id;
   }
 
-  // Don't continue with the exit procedure until all profiles have finished.
-  if (exiting_ && pending_cpu_profile_data_map_.empty()) {
-    uv_mutex_lock(&stop_lock_);
-    uv_cond_signal(&stop_cond_);
-    uv_mutex_unlock(&stop_lock_);
-  }
-
   // get start_ts and metadata from pending_cpu_profile_data_map_
   if (status < 0) {
     // Send error message back
@@ -2244,6 +2237,13 @@ std::string ZmqAgent::got_cpu_profile(int status,
              thread_id,
              version_);
     bulk_handle_->send(msg_buf_, profile);
+  }
+
+  // Don't continue with the exit procedure until all profiles have finished.
+  if (exiting_ && pending_cpu_profile_data_map_.empty()) {
+    uv_mutex_lock(&stop_lock_);
+    uv_cond_signal(&stop_cond_);
+    uv_mutex_unlock(&stop_lock_);
   }
 
   return req_id;


### PR DESCRIPTION
Make sure, as much as possible, that the full asset is sent to the Console by signallint the `stop_cond_` after the data is sent. Observed while stress-testing `test-zmq-profile.mjs` where the process would exit before the data was sent.

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
