### PR TITLE
agents: implement data handle ring buffer

### DIFF
--- a/agents/zmq/src/zmq_agent.h
+++ b/agents/zmq/src/zmq_agent.h
@@ -583,7 +583,7 @@ class ZmqAgent {
                            const char* request_id,
                            const char* body);
 
-  int send_data_msg(const std::string& msg) const;
+  int send_data_msg(const char* buf, size_t len);
 
   void send_exit();
 
@@ -646,6 +646,7 @@ class ZmqAgent {
   ZmqContext context_;
   std::unique_ptr<ZmqCommandHandle> command_handle_;
   std::unique_ptr<ZmqDataHandle> data_handle_;
+  utils::RingBuffer<std::string> data_ring_buffer_;
   std::unique_ptr<ZmqBulkHandle> bulk_handle_;
   int version_;
   nsuv::ns_timer invalid_key_timer_;

--- a/node.gyp
+++ b/node.gyp
@@ -444,6 +444,7 @@
       'test/cctest/http_server_fixture.h',
       'test/cctest/test_agents_zmq_http_client.cc',
       'test/cctest/test_nsolid_lru_map.cc',
+      'test/cctest/test_nsolid_ring_buffer.cc',
       'test/cctest/test_nsolid_thread_safe.cc',
     ],
     'node_cctest_openssl_sources': [

--- a/src/nsolid/nsolid_util.h
+++ b/src/nsolid/nsolid_util.h
@@ -193,6 +193,67 @@ class ring_buffer {
   std::vector<double> buffer_;
 };
 
+template <typename T>
+class RingBuffer {
+ public:
+  NSOLID_DELETE_DEFAULT_CONSTRUCTORS(RingBuffer)
+  explicit RingBuffer(size_t s)
+      : capacity_(s),
+        size_(0),
+        head_(0),
+        tail_(0) {
+    buffer_ = new T[s];
+  }
+
+  ~RingBuffer() {
+    delete[] buffer_;
+  }
+
+  bool empty() const {
+    return size_ == 0;
+  }
+
+  // Make sure to check empty() first otherwise an invalid value will be
+  // returned.
+  T& front() {
+    return buffer_[head_];
+  }
+
+  void pop() {
+    if (empty())
+      return;
+    head_ = (head_ + 1) % capacity_;
+    size_--;
+  }
+
+  void push(T& value) {
+    buffer_[tail_] = value;
+    tail_ = (tail_ + 1) % capacity_;
+
+    if (size_ == capacity_)
+      head_ = (head_ + 1) % capacity_;
+    else
+      size_++;
+  }
+
+  void push(T&& value) {
+    buffer_[tail_] = value;
+    tail_ = (tail_ + 1) % capacity_;
+
+    if (size_ == capacity_)
+      head_ = (head_ + 1) % capacity_;
+    else
+      size_++;
+  }
+
+ private:
+  T* buffer_;
+  const size_t capacity_;
+  size_t size_;
+  size_t head_;
+  size_t tail_;
+};
+
 }  // namespace utils
 }  // namespace nsolid
 }  // namespace node

--- a/test/cctest/test_nsolid_ring_buffer.cc
+++ b/test/cctest/test_nsolid_ring_buffer.cc
@@ -1,0 +1,39 @@
+#include "gtest/gtest.h"
+#include "nsolid/nsolid_util.h"
+
+using node::nsolid::utils::RingBuffer;
+
+TEST(RingBufferTest, Basic) {
+  // Create a buffer of size 3.
+  RingBuffer<int> buffer(3);
+
+  // Test that the buffer is initially empty.
+  EXPECT_TRUE(buffer.empty());
+
+  // Push some elements into the buffer.
+  buffer.push(1);
+  buffer.push(2);
+  buffer.push(3);
+
+  // Test that the buffer is not empty.
+  EXPECT_FALSE(buffer.empty());
+
+  // Test that the front of the buffer is the first element pushed.
+  EXPECT_EQ(buffer.front(), 1);
+
+  // Pop an element and test that the front of the buffer is the second element
+  // pushed.
+  buffer.pop();
+  EXPECT_EQ(buffer.front(), 2);
+
+  // Push another element and test that the front of the buffer is still the
+  // second element pushed.
+  buffer.push(4);
+  EXPECT_EQ(buffer.front(), 2);
+
+  // Push another element. This should cause the second element to be popped
+  // (since the buffer size is 3), so the front of the buffer should now be the
+  // third element pushed.
+  buffer.push(5);
+  EXPECT_EQ(buffer.front(), 3);
+}


### PR DESCRIPTION
Add a basic `RingBuffer<T>` implementation to `nsolid_util.h` with accompanying tests.

Use it for ZMQ `data` channel messages, so we're able to buffer up to `MAX_DATA_BUFFER_SIZE` messages in case of channel disconnection. Fixes problems observed while load testing the agent, where data messages were generated before the actual `data` channel connection was established and were actually dropped.

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
