### PR TITLE
Multiple fixes for Windows

### DIFF
--- a/agents/statsd/src/statsd_agent.h
+++ b/agents/statsd/src/statsd_agent.h
@@ -180,7 +180,7 @@ class StatsDAgent {
 
   void operator delete(void*) = delete;
 
-  static std::atomic<bool> is_running;
+  static std::atomic<bool> is_running_;
 
   static const std::vector<std::string> metrics_fields;
 

--- a/src/nsolid.h
+++ b/src/nsolid.h
@@ -237,26 +237,34 @@ template <typename G>
 void delete_proxy_(void* g);
 
 
-int queue_callback_(void*, queue_callback_proxy_sig);
-int queue_callback_(uint64_t, void*, queue_callback_proxy_sig);
-int run_command_(SharedEnvInst, CommandType, void*, run_command_proxy_sig);
-int custom_command_(SharedEnvInst,
-                    std::string,
-                    std::string,
-                    std::string,
-                    void*,
-                    custom_command_proxy_sig);
-int at_exit_hook_(void*, at_exit_hook_proxy_sig, deleter_sig);
-void on_block_loop_hook_(uint64_t,
-                         void*,
-                         on_block_loop_hook_proxy_sig,
-                         deleter_sig);
-void on_unblock_loop_hook_(void*, on_unblock_loop_hook_proxy_sig, deleter_sig);
-void on_configuration_hook_(void*,
-                            on_configuration_hook_proxy_sig,
-                            deleter_sig);
-void thread_added_hook_(void*, thread_added_hook_proxy_sig, deleter_sig);
-void thread_removed_hook_(void*, thread_removed_hook_proxy_sig, deleter_sig);
+NODE_EXTERN int queue_callback_(void*, queue_callback_proxy_sig);
+NODE_EXTERN int queue_callback_(uint64_t, void*, queue_callback_proxy_sig);
+NODE_EXTERN int run_command_(SharedEnvInst,
+                             CommandType, void*,
+                             run_command_proxy_sig);
+NODE_EXTERN int custom_command_(SharedEnvInst,
+                                std::string,
+                                std::string,
+                                std::string,
+                                void*,
+                                custom_command_proxy_sig);
+NODE_EXTERN int at_exit_hook_(void*, at_exit_hook_proxy_sig, deleter_sig);
+NODE_EXTERN void on_block_loop_hook_(uint64_t,
+                                     void*,
+                                     on_block_loop_hook_proxy_sig,
+                                     deleter_sig);
+NODE_EXTERN void on_unblock_loop_hook_(void*,
+                                       on_unblock_loop_hook_proxy_sig,
+                                       deleter_sig);
+NODE_EXTERN void on_configuration_hook_(void*,
+                                        on_configuration_hook_proxy_sig,
+                                        deleter_sig);
+NODE_EXTERN void thread_added_hook_(void*,
+                                    thread_added_hook_proxy_sig,
+                                    deleter_sig);
+NODE_EXTERN void thread_removed_hook_(void*,
+                                      thread_removed_hook_proxy_sig,
+                                      deleter_sig);
 
 }  // namespace internal
 

--- a/src/nsolid/nsolid_api.h
+++ b/src/nsolid/nsolid_api.h
@@ -3,6 +3,8 @@
 
 #if defined(NODE_WANT_INTERNALS) && NODE_WANT_INTERNALS
 
+#define NSOLID_EXTERN_PRIVATE NODE_EXTERN
+
 #include <atomic>
 #include <functional>
 #include <list>
@@ -25,6 +27,7 @@
 // We can export it via ADDONS_PREREQS in the Makefile and link against it with
 // our native module builds that depend on it
 #include "nlohmann/json.hpp"
+
 
 namespace node {
 namespace nsolid {
@@ -462,7 +465,7 @@ class EnvList {
   };
 
   // Return the one true instance.
-  static EnvList* Inst();
+  NSOLID_EXTERN_PRIVATE static EnvList* Inst();
 
   // This call is thread-safe.
   std::string AgentId();
@@ -493,8 +496,10 @@ class EnvList {
 
   // Queue callbacks to run on the EnvList thread without reference to a
   // specific EnvInst instance.
-  int QueueCallback(q_cb_sig cb, void* data);
-  int QueueCallback(q_cb_sig cb, uint64_t timeout, void* data);
+  NSOLID_EXTERN_PRIVATE int QueueCallback(q_cb_sig cb, void* data);
+  NSOLID_EXTERN_PRIVATE int QueueCallback(q_cb_sig cb,
+                                          uint64_t timeout,
+                                          void* data);
 
   // These should only be called from node threads.
   void AddEnv(Environment* env);

--- a/test/addons/nsolid-agent-id/binding.cc
+++ b/test/addons/nsolid-agent-id/binding.cc
@@ -1,32 +1,18 @@
 #include <node.h>
 #include <v8.h>
-#include <nsolid/nsolid_api.h>
+#include <nsolid.h>
 
 #include <assert.h>
-
-using node::nsolid::EnvInst;
-using node::nsolid::EnvList;
-
-// While node::AtExit can run for any Environment, we only have this set to run
-// on the Environment of the main thread. So by this point the env_map_size
-// should equal 0.
-static void at_exit(void*) {
-  assert(EnvList::Inst()->env_map_size() == 1);
-}
 
 // JS related functions //
 
 static void AgentId(const v8::FunctionCallbackInfo<v8::Value>& args) {
   return args.GetReturnValue().Set(
     v8::String::NewFromUtf8(args.GetIsolate(),
-                            EnvList::Inst()->AgentId().c_str(),
+                            node::nsolid::GetAgentId().c_str(),
                             v8::NewStringType::kNormal).ToLocalChecked());
 }
 
 NODE_MODULE_INIT(/* exports, module, context */) {
   NODE_SET_METHOD(exports, "agentId", AgentId);
-  // While NODE_MODULE_INIT will run for every Worker, the first execution
-  // won't run in parallel with another. So this won't cause a race condition.
-  if (EnvInst::GetEnvLocalInst(context->GetIsolate())->thread_id() == 0)
-    node::AtExit(node::GetCurrentEnvironment(context), at_exit, nullptr);
 }

--- a/test/addons/nsolid-config-hooks/binding.cc
+++ b/test/addons/nsolid-config-hooks/binding.cc
@@ -1,22 +1,12 @@
 #include <node.h>
 #include <v8.h>
-#include <nsolid/nsolid_api.h>
+#include <nsolid.h>
 
 #include <assert.h>
 #include <memory>
 #include <string>
 
-using node::nsolid::EnvInst;
-using node::nsolid::EnvList;
-
 std::atomic<int> config_count = { 0 };
-
-// While node::AtExit can run for any Environment, we only have this set to run
-// on the Environment of the main thread. So by this point the env_map_size
-// should equal 0.
-static void at_exit(void*) {
-  assert(EnvList::Inst()->env_map_size() == 1);
-}
 
 static void did_config(std::string config) {
   config_count++;
@@ -32,8 +22,8 @@ NODE_MODULE_INIT(/* exports, module, context */) {
   NODE_SET_METHOD(exports, "checkConfig", CheckConfig);
   // While NODE_MODULE_INIT will run for every Worker, the first execution
   // won't run in parallel with another. So this won't cause a race condition.
-  if (EnvInst::GetEnvLocalInst(context->GetIsolate())->thread_id() == 0) {
-    node::AtExit(node::GetCurrentEnvironment(context), at_exit, nullptr);
+  node::nsolid::SharedEnvInst envinst = node::nsolid::GetLocalEnvInst(context);
+  if (node::nsolid::IsMainThread(envinst)) {
     node::nsolid::OnConfigurationHook(did_config);
   }
 }

--- a/test/addons/nsolid-custom-command/binding.cc
+++ b/test/addons/nsolid-custom-command/binding.cc
@@ -1,12 +1,14 @@
 #include <node.h>
 #include <util-inl.h>
 #include <v8.h>
-#include <nsolid/nsolid_api.h>
+#include <nsolid.h>
 
 #include <assert.h>
+#include <map>
 #include <memory>
 #include <string>
 
+using node::nsolid::SharedEnvInst;
 using v8::Context;
 using v8::Function;
 using v8::FunctionCallbackInfo;
@@ -22,9 +24,6 @@ using v8::String;
 using v8::Undefined;
 using v8::Value;
 
-using node::nsolid::EnvInst;
-using node::nsolid::EnvList;
-
 std::map<std::string, Global<Function>> cb_map_;
 
 template <class TypeName>
@@ -33,14 +32,6 @@ static inline Local<TypeName> PersistentToLocalStrong(
   assert(!persistent.IsWeak());
   return *reinterpret_cast<Local<TypeName>*>(
       const_cast<PersistentBase<TypeName>*>(&persistent));
-}
-
-// While node::AtExit can run for any Environment, we only have this set to run
-// on the Environment of the main thread. So by this point the env_map_size
-// should equal 0.
-static void at_exit(void*) {
-  cb_map_.clear();
-  assert(EnvList::Inst()->env_map_size() == 1);
 }
 
 static void custom_command_cb(std::string req_id,
@@ -94,7 +85,7 @@ static void CustomCommand(const FunctionCallbackInfo<Value>& args) {
   assert(args[3]->IsFunction());
   Isolate* isolate = args.GetIsolate();
   Local<Context> context = isolate->GetCurrentContext();
-  auto envinst_sp = EnvInst::GetCurrent(context);
+  SharedEnvInst envinst_sp = node::nsolid::GetLocalEnvInst(context);
 
   Local<String> req_id_s = args[0].As<String>();
   String::Utf8Value req_id(isolate, req_id_s);
@@ -159,8 +150,4 @@ NODE_MODULE_INIT(/* exports, module, context */) {
   NODE_SET_METHOD(exports, "customCommand", CustomCommand);
   NODE_SET_METHOD(exports, "customCommandThread", CustomCommandThread);
   NODE_SET_METHOD(exports, "setCustomCommandCb", SetCustomCommandCb);
-  // While NODE_MODULE_INIT will run for every Worker, the first execution
-  // won't run in parallel with another. So this won't cause a race condition.
-  if (EnvInst::GetEnvLocalInst(context->GetIsolate())->thread_id() == 0)
-    node::AtExit(node::GetCurrentEnvironment(context), at_exit, nullptr);
 }

--- a/test/addons/nsolid-dispatchqueue/binding.cc
+++ b/test/addons/nsolid-dispatchqueue/binding.cc
@@ -3,9 +3,6 @@
 #include <nsolid/nsolid_api.h>
 
 #include <assert.h>
-
-using node::nsolid::EnvInst;
-using node::nsolid::EnvList;
 using node::nsolid::DispatchQueue;
 
 struct Foo {
@@ -13,13 +10,6 @@ struct Foo {
 
 DispatchQueue<Foo> global_qd;
 Foo foo;
-
-// While node::AtExit can run for any Environment, we only have this set to run
-// on the Environment of the main thread. So by this point the env_map_size
-// should equal 0.
-static void at_exit(void*) {
-  assert(EnvList::Inst()->env_map_size() == 1);
-}
 
 // JS related functions //
 
@@ -53,11 +43,4 @@ static void EnqueueItem(const v8::FunctionCallbackInfo<v8::Value>& args) {
 NODE_MODULE_INIT(/* exports, module, context */) {
   NODE_SET_METHOD(exports, "runDispatch", RunDispatch);
   NODE_SET_METHOD(exports, "enqueueItem", EnqueueItem);
-
-  // While NODE_MODULE_INIT will run for every Worker, the first execution
-  // won't run in parallel with another. So this won't cause a race condition.
-  if (EnvInst::GetEnvLocalInst(context->GetIsolate())->thread_id() != 0)
-    return;
-
-  node::AtExit(node::GetCurrentEnvironment(context), at_exit, nullptr);
 }

--- a/test/addons/nsolid-env-hooks/binding.cc
+++ b/test/addons/nsolid-env-hooks/binding.cc
@@ -1,12 +1,9 @@
 #include <node.h>
 #include <v8.h>
-#include <nsolid/nsolid_api.h>
+#include <nsolid.h>
 
 #include <assert.h>
 #include <atomic>
-
-using node::nsolid::EnvInst;
-using node::nsolid::EnvList;
 
 std::atomic<uint32_t> cntr = { 0 };
 
@@ -14,7 +11,6 @@ std::atomic<uint32_t> cntr = { 0 };
 // on the Environment of the main thread. So by this point the env_map_size
 // should equal 0.
 static void at_exit(void*) {
-  assert(EnvList::Inst()->env_map_size() == 1);
   assert(cntr == 0);
 }
 
@@ -31,7 +27,8 @@ static void env_deletion(node::nsolid::SharedEnvInst envinst) {
 NODE_MODULE_INIT(/* exports, module, context */) {
   // While NODE_MODULE_INIT will run for every Worker, the first execution
   // won't run in parallel with another. So this won't cause a race condition.
-  if (EnvInst::GetEnvLocalInst(context->GetIsolate())->thread_id() == 0) {
+  node::nsolid::SharedEnvInst envinst = node::nsolid::GetLocalEnvInst(context);
+  if (node::nsolid::IsMainThread(envinst)) {
     node::AtExit(node::GetCurrentEnvironment(context), at_exit, nullptr);
     node::nsolid::ThreadAddedHook(env_creation);
     node::nsolid::ThreadRemovedHook(env_deletion);

--- a/test/addons/nsolid-exit/binding.cc
+++ b/test/addons/nsolid-exit/binding.cc
@@ -1,33 +1,22 @@
 #include <node.h>
 #include <v8.h>
-#include <nsolid/nsolid_api.h>
+#include <nsolid.h>
 
 
 #include <assert.h>
-
-using node::nsolid::EnvInst;
-using node::nsolid::EnvList;
 using error_tup = std::tuple<std::string, std::string>;
 using exit_hook_tup = std::tuple<int, error_tup*, bool>;
 
 static int hooks_set;
 static int hooks_called;
 
-// While node::AtExit can run for any Environment, we only have this set to run
-// on the Environment of the main thread. So by this point the env_map_size
-// should equal 0.
-static void at_exit(void*) {
-  assert(EnvList::Inst()->env_map_size() == 1);
-}
-
 static void at_exit_hook(bool on_signal,
                          bool profile_stopped,
                          exit_hook_tup* tup) {
   fprintf(stdout, "at_exit_hook");
   ++hooks_called;
-  EnvList* envlist = EnvList::Inst();
-  auto* error = envlist->GetExitError();
-  int exit_code = envlist->GetExitCode();
+  auto* error = node::nsolid::GetExitError();
+  int exit_code = node::nsolid::GetExitCode();
   error_tup* e_tup = std::get<1>(*tup);
   if (error == nullptr) {
     assert(e_tup == nullptr);
@@ -70,8 +59,4 @@ static void SetExitInfo(const v8::FunctionCallbackInfo<v8::Value>& args) {
 
 NODE_MODULE_INIT(/* exports, module, context */) {
   NODE_SET_METHOD(exports, "setExitInfo", SetExitInfo);
-  // While NODE_MODULE_INIT will run for every Worker, the first execution
-  // won't run in parallel with another. So this won't cause a race condition.
-  if (EnvInst::GetEnvLocalInst(context->GetIsolate())->thread_id() == 0)
-    node::AtExit(node::GetCurrentEnvironment(context), at_exit, nullptr);
 }

--- a/test/addons/nsolid-proc-metrics/binding.cc
+++ b/test/addons/nsolid-proc-metrics/binding.cc
@@ -1,19 +1,11 @@
 #include <node.h>
 #include <v8.h>
 #include <nsolid.h>
-#include <nsolid/nsolid_api.h>
 
 #include <assert.h>
 
-using node::nsolid::EnvInst;
-using node::nsolid::EnvList;
-
 node::nsolid::ProcessMetrics proc_metrics_;
 node::nsolid::ProcessMetrics::MetricsStor proc_stor;
-
-static void at_exit(void*) {
-  assert(EnvList::Inst()->env_map_size() == 1);
-}
 
 static void GetMetrics(const v8::FunctionCallbackInfo<v8::Value>& args) {
   assert(0 == proc_metrics_.Update());
@@ -23,9 +15,4 @@ static void GetMetrics(const v8::FunctionCallbackInfo<v8::Value>& args) {
 
 NODE_MODULE_INIT(/* exports, module, context */) {
   NODE_SET_METHOD(exports, "getMetrics", GetMetrics);
-  // While NODE_MODULE_INIT will run for every Worker, the first execution
-  // won't run in parallel with another. So this won't cause a race condition.
-  if (EnvInst::GetEnvLocalInst(context->GetIsolate())->thread_id() == 0) {
-    node::AtExit(node::GetCurrentEnvironment(context), at_exit, nullptr);
-  }
 }

--- a/test/addons/nsolid-queue-cb/binding.cc
+++ b/test/addons/nsolid-queue-cb/binding.cc
@@ -1,16 +1,19 @@
 #include <node.h>
 #include <uv.h>
 #include <v8.h>
-#include <nsolid/nsolid_api.h>
+#include <nsolid.h>
 
 #include <assert.h>
 #include <atomic>
 
-using node::nsolid::EnvInst;
-using node::nsolid::EnvList;
-
 using v8::FunctionCallbackInfo;
 using v8::Value;
+
+struct Foo {
+  int i;
+};
+
+Foo foo;
 
 std::atomic<int> init_cntr = { 0 };
 std::atomic<int> run_cntr = { 0 };
@@ -22,7 +25,6 @@ std::atomic<int> cb_fn3_0_cntr = { 0 };
 std::atomic<int> cb_fn3_1_cntr = { 0 };
 
 static void at_exit(void*) {
-  assert(EnvList::Inst()->env_map_size() == 1);
   assert(init_cntr == 1);
   assert(run_cntr == cb_fn2_0_cntr);
   assert(run_cntr == cb_fn2_1_cntr);
@@ -36,36 +38,39 @@ static void cb_fn2_1(int i) {
   assert(40 == i);
   cb_fn2_1_cntr++;
 }
-static void cb_fn2_2(EnvList*, int i) {
+static void cb_fn2_2(Foo* f, int i) {
+  assert(f == &foo);
   assert(41 == i);
   cb_fn2_2_cntr++;
 }
-static void cb_fn2_3(EnvList*, EnvList*, int i) {
+static void cb_fn2_3(Foo* f1, Foo* f2, int i) {
+  assert(f1 == &foo);
+  assert(f2 == &foo);
   assert(42 == i);
   cb_fn2_3_cntr++;
 }
 static void cb_fn3() { cb_fn3_0_cntr++; }
-static void cb_fn3_1(EnvList*) { cb_fn3_1_cntr++; }
+static void cb_fn3_1(Foo* f) { cb_fn3_1_cntr++; }
 
 // JS related functions //
 
 void QueueCb(const FunctionCallbackInfo<Value>& args) {
-  EnvList* envlist = EnvList::Inst();
   uint64_t timeout = 100;
   run_cntr++;
   assert(0 == node::nsolid::QueueCallback(cb_fn2));
   assert(0 == node::nsolid::QueueCallback(cb_fn2_1, 40));
-  assert(0 == node::nsolid::QueueCallback(cb_fn2_2, envlist, 41));
-  assert(0 == node::nsolid::QueueCallback(cb_fn2_3, envlist, envlist, 42));
+  assert(0 == node::nsolid::QueueCallback(cb_fn2_2, &foo, 41));
+  assert(0 == node::nsolid::QueueCallback(cb_fn2_3, &foo, &foo, 42));
   assert(0 == node::nsolid::QueueCallback(timeout, cb_fn3));
-  assert(0 == node::nsolid::QueueCallback(timeout, cb_fn3_1, envlist));
+  assert(0 == node::nsolid::QueueCallback(timeout, cb_fn3_1, &foo));
 }
 
 NODE_MODULE_INIT(/* exports, module, context */) {
   NODE_SET_METHOD(exports, "queueCallback", QueueCb);
   // While NODE_MODULE_INIT will run for every Worker, the first execution
   // won't run in parallel with another. So this won't cause a race condition.
-  if (EnvInst::GetCurrent(context)->thread_id() == 0) {
+  node::nsolid::SharedEnvInst envinst = node::nsolid::GetLocalEnvInst(context);
+  if (node::nsolid::IsMainThread(envinst)) {
     init_cntr++;
     node::AtExit(node::GetCurrentEnvironment(context), at_exit, nullptr);
   }

--- a/test/addons/nsolid-run-command/binding.cc
+++ b/test/addons/nsolid-run-command/binding.cc
@@ -1,22 +1,15 @@
 #include <node.h>
 #include <uv.h>
 #include <v8.h>
-#include <nsolid/nsolid_api.h>
+#include <nsolid.h>
 
 #include <assert.h>
-
-using node::nsolid::EnvInst;
-using node::nsolid::EnvList;
 
 using v8::FunctionCallbackInfo;
 using v8::Value;
 
 std::atomic<int> interrupt_cb_cntr = { 0 };
 std::atomic<int> interrupt_only_cb_cntr = { 0 };
-
-static void at_exit(void*) {
-  assert(EnvList::Inst()->env_map_size() == 1);
-}
 
 static void interrupt_cb(node::nsolid::SharedEnvInst) {
   ++interrupt_cb_cntr;
@@ -59,9 +52,4 @@ NODE_MODULE_INIT(/* exports, module, context */) {
   NODE_SET_METHOD(exports, "getInterruptOnlyCntr", GetInterruptOnlyCntr);
   NODE_SET_METHOD(exports, "runInterrupt", RunInterrupt);
   NODE_SET_METHOD(exports, "runInterruptOnly", RunInterruptOnly);
-  // While NODE_MODULE_INIT will run for every Worker, the first execution
-  // won't run in parallel with another. So this won't cause a race condition.
-  if (EnvInst::GetCurrent(context)->thread_id() == 0) {
-    node::AtExit(node::GetCurrentEnvironment(context), at_exit, nullptr);
-  }
 }


### PR DESCRIPTION
Multiple fixes for issues uncovered while running N|Solid intensively on Windows.
```
agents: fix OTLP agent deadlock on stop
```
```
agents: fix race conditions on StatsDAgent
    
Add an `exit_lock_` to avoid accessing a destroyed `StatsDAgent`
instance on static callbacks.
Move a static string (`def_bucket`) out of the class to avoid it's
destroyed before the `StatsDAgent` singleton, which would cause a nasty
deadlock on Windows.
Add other safeguards to avoid race conditions.
```
```
src: export nsolid.h static functions
    
So building native addons on Windows actually works.
```
```
src,test: refactor addon tests
    
Refactor most of the addon tests to use the nsolid public API.
In the cases where we want to test internals, define
`NSOLID_EXTERN_PRIVATE` as `NODE_EXTERN` and use it in the internal
functions we want to test.
```
```
build,win: add test-agents-prereqs target
    
For the zmq agent tests.
```