### PR TITLE
src: make ProcessMetrics API thread-safe

### DIFF
--- a/src/nsolid.h
+++ b/src/nsolid.h
@@ -561,7 +561,7 @@ class NODE_EXTERN ProcessMetrics {
    * @brief Destroy the Process Metrics object
    *
    */
-  ~ProcessMetrics() = default;
+  ~ProcessMetrics();
 
   /**
    * @brief struct to store process metrics data.
@@ -598,6 +598,7 @@ class NODE_EXTERN ProcessMetrics {
   int Update();
 
  private:
+  uv_mutex_t stor_lock_;
   MetricsStor stor_;
   uint64_t cpu_prev_[3];
   uint64_t cpu_prev_time_;

--- a/src/nsolid/nsolid_util.h
+++ b/src/nsolid/nsolid_util.h
@@ -226,7 +226,7 @@ class RingBuffer {
     size_--;
   }
 
-  void push(T& value) {
+  void push(const T& value) {
     buffer_[tail_] = value;
     tail_ = (tail_ + 1) % capacity_;
 

--- a/test/addons/nsolid-proc-metrics/binding.cc
+++ b/test/addons/nsolid-proc-metrics/binding.cc
@@ -5,11 +5,10 @@
 #include <assert.h>
 
 node::nsolid::ProcessMetrics proc_metrics_;
-node::nsolid::ProcessMetrics::MetricsStor proc_stor;
 
 static void GetMetrics(const v8::FunctionCallbackInfo<v8::Value>& args) {
   assert(0 == proc_metrics_.Update());
-  proc_stor = proc_metrics_.Get();
+  node::nsolid::ProcessMetrics::MetricsStor proc_stor = proc_metrics_.Get();
   assert(proc_stor.system_uptime > 0);
 }
 


### PR DESCRIPTION
Previous calls to `Update()` or `Get()` could cause corruption because they could attempt to write to `stor_` from different threads. Put a lock around all access to `stor_` so that doesn't happen.
