### PR TITLE
StatsDAgent fixes, improvements and tests

### DIFF
--- a/agents/statsd/src/binding.cc
+++ b/agents/statsd/src/binding.cc
@@ -152,7 +152,7 @@ static void RegisterStatusCb(const FunctionCallbackInfo<Value>& args) {
         status.c_str(),
         NewStringType::kNormal).ToLocalChecked();
 
-      cb->Call(context, Undefined(isolate), 1, &argv).ToLocalChecked();
+      USE(cb->Call(context, Undefined(isolate), 1, &argv));
     }));
 
   ASSERT_NOT_NULL(status_cb_pair_);

--- a/agents/statsd/src/binding.cc
+++ b/agents/statsd/src/binding.cc
@@ -42,6 +42,14 @@ static void Bucket(const FunctionCallbackInfo<Value>& args) {
 
 static void Status(const FunctionCallbackInfo<Value>& args) {
   Isolate* isolate = args.GetIsolate();
+  if (!StatsDAgent::is_running_) {
+    args.GetReturnValue().Set(
+      String::NewFromUtf8(isolate,
+                          "unconfigured",
+                          NewStringType::kNormal).ToLocalChecked());
+    return;
+  }
+
   args.GetReturnValue().Set(
     String::NewFromUtf8(isolate,
                         StatsDAgent::Inst()->status().c_str(),

--- a/agents/statsd/src/statsd_agent.cc
+++ b/agents/statsd/src/statsd_agent.cc
@@ -907,7 +907,7 @@ void StatsDAgent::setup_udp() {
 void StatsDAgent::status_command_cb_(SharedEnvInst, StatsDAgent* agent) {
   // Check if the agent is already delete or if it's closing
   nsuv::ns_rwlock::scoped_rdlock lock(exit_lock_);
-  if (!is_running_ || agent->status_ == Unconfigured) {
+  if (!is_running_) {
     return;
   }
 

--- a/agents/statsd/src/statsd_agent.cc
+++ b/agents/statsd/src/statsd_agent.cc
@@ -396,6 +396,8 @@ void StatsDAgent::do_start() {
 
   ASSERT_EQ(0, metrics_timer_.init(&loop_));
 
+  status(Initializing);
+
   if (hooks_init_ == false) {
     ASSERT_EQ(0, OnConfigurationHook(config_agent_cb, this));
     ASSERT_EQ(0, ThreadAddedHook(env_creation_cb, this));
@@ -403,7 +405,6 @@ void StatsDAgent::do_start() {
     hooks_init_ = true;
   }
 
-  status(Initializing);
   uv_cond_signal(&start_cond_);
   uv_mutex_unlock(&start_lock_);
 }

--- a/agents/statsd/src/statsd_agent.cc
+++ b/agents/statsd/src/statsd_agent.cc
@@ -881,6 +881,7 @@ void StatsDAgent::setup_tcp() {
   if (tcp_) {
     tcp_->close_and_delete();
   }
+  addr_index_ = 0;
   tcp_ = new StatsDTcp(&loop_, &update_state_msg_);
   auto* ss = &endpoint_->addresses()[addr_index_];
   auto* addr = reinterpret_cast<const struct sockaddr*>(ss);
@@ -890,6 +891,7 @@ void StatsDAgent::setup_tcp() {
 void StatsDAgent::setup_udp() {
   udp_.reset(nullptr);
   udp_.reset(new StatsDUdp(&loop_, &update_state_msg_));
+  addr_index_ = 0;
   auto* ss = &endpoint_->addresses()[addr_index_];
   auto* addr = reinterpret_cast<const struct sockaddr*>(ss);
   if (udp_->connect(addr) != 0) {

--- a/agents/statsd/src/statsd_agent.cc
+++ b/agents/statsd/src/statsd_agent.cc
@@ -444,7 +444,6 @@ void StatsDAgent::do_stop() {
   shutdown_.close();
   metrics_timer_.close();
   retry_timer_.close();
-  env_metrics_map_.clear();
 }
 
 void StatsDAgent::run_(nsuv::ns_thread*, StatsDAgent* agent) {

--- a/agents/statsd/src/statsd_agent.cc
+++ b/agents/statsd/src/statsd_agent.cc
@@ -427,8 +427,10 @@ int StatsDAgent::stop() {
 }
 
 void StatsDAgent::do_stop() {
-  status(Unconfigured);
-  tcp_.reset(nullptr);
+  {
+    nsuv::ns_rwlock::scoped_wrlock lock(exit_lock_);
+    status(Unconfigured);
+  }
   if (tcp_) {
     tcp_->close_and_delete();
     tcp_ = nullptr;

--- a/agents/statsd/src/statsd_agent.h
+++ b/agents/statsd/src/statsd_agent.h
@@ -134,6 +134,8 @@ class StatsDAgent {
 #undef X
   };
 
+  static std::atomic<bool> is_running_;
+
   static StatsDAgent* Inst();
 
   int setup_metrics_timer(uint64_t period);
@@ -190,8 +192,6 @@ class StatsDAgent {
   ~StatsDAgent();
 
   void operator delete(void*) = delete;
-
-  static std::atomic<bool> is_running_;
 
   static const std::vector<std::string> metrics_fields;
 

--- a/src/nsolid/nsolid_api.cc
+++ b/src/nsolid/nsolid_api.cc
@@ -1056,7 +1056,8 @@ void EnvList::UpdateConfig(const nlohmann::json& config) {
       otlp::OTLPAgent::Inst()->start();
     }
 
-    if (config.find("statsd") != config.end()) {
+    it = config.find("statsd");
+    if (it != config.end() && !it->is_null()) {
       statsd::StatsDAgent::Inst()->start();
     }
 

--- a/test/agents/test-statsd-connection.js
+++ b/test/agents/test-statsd-connection.js
@@ -1,0 +1,273 @@
+// Flags: --expose-internals
+
+'use strict';
+
+require('../common');
+const assert = require('node:assert');
+const { EventEmitter } = require('node:events');
+const { after, afterEach, before, describe, it } = require('node:test');
+const nsolid = require('nsolid');
+const dgram = require('dgram');
+const net = require('net');
+const readline = require('readline');
+const stream = require('stream');
+const { internalBinding } = require('internal/test/binding');
+const bindings = internalBinding('nsolid_statsd_agent');
+
+const expectedMetrics = [
+  'blockInputOpCount',
+  'blockOutputOpCount',
+  'cpuPercent',
+  'cpuSystemPercent',
+  'cpuUserPercent',
+  'ctxSwitchInvoluntaryCount',
+  'ctxSwitchVoluntaryCount',
+  'freeMem',
+  'ipcReceivedCount',
+  'ipcSentCount',
+  'load15m',
+  'load1m',
+  'load5m',
+  'pageFaultHardCount',
+  'pageFaultSoftCount',
+  'rss',
+  'signalCount',
+  'swapCount',
+  'systemUptime',
+  'timestamp',
+  'uptime',
+  'activeHandles',
+  'activeRequests',
+  'dns99Ptile',
+  'dnsCount',
+  'dnsMedian',
+  'eventsProcessed',
+  'eventsWaiting',
+  'externalMem',
+  'fsHandlesClosedCount',
+  'fsHandlesOpenedCount',
+  'gcCount',
+  'gcDurUs99Ptile',
+  'gcDurUsMedian',
+  'gcForcedCount',
+  'gcFullCount',
+  'gcMajorCount',
+  'heapSizeLimit',
+  'heapTotal',
+  'heapUsed',
+  'httpClient99Ptile',
+  'httpClientAbortCount',
+  'httpClientCount',
+  'httpClientMedian',
+  'httpServer99Ptile',
+  'httpServerAbortCount',
+  'httpServerCount',
+  'httpServerMedian',
+  'loopAvgTasks',
+  'loopEstimatedLag',
+  'loopIdlePercent',
+  'loopIdleTime',
+  'loopIterWithEvents',
+  'loopIterations',
+  'loopTotalCount',
+  'loopUtilization',
+  'mallocedMemory',
+  'numberOfDetachedContexts',
+  'numberOfNativeContexts',
+  'peakMallocedMemory',
+  'pipeServerCreatedCount',
+  'pipeServerDestroyedCount',
+  'pipeSocketCreatedCount',
+  'pipeSocketDestroyedCount',
+  'processingDelay',
+  'promiseCreatedCount',
+  'promiseResolvedCount',
+  'providerDelay',
+  'res15m',
+  'res1m',
+  'res5m',
+  'res5s',
+  'tcpServerCreatedCount',
+  'tcpServerDestroyedCount',
+  'tcpSocketCreatedCount',
+  'tcpSocketDestroyedCount',
+  'threadId',
+  'timestamp',
+  'totalAvailableSize',
+  'totalHeapSizeExecutable',
+  'totalPhysicalSize',
+  'udpSocketCreatedCount',
+  'udpSocketDestroyedCount',
+];
+
+const ee = new EventEmitter();
+let status_ = 'unconfigured';
+bindings._registerStatusCb((status) => {
+  if (status !== status_) {
+    status_ = status;
+    ee.emit('status', status);
+  }
+});
+
+async function waitForStatus(status) {
+  return new Promise((resolve, reject) => {
+    if (status_ === status) {
+      resolve();
+      return;
+    }
+
+    ee.on('status', (s) => {
+      if (s === status) {
+        ee.removeAllListeners('status');
+        resolve();
+      }
+    });
+  });
+}
+
+async function startTcpServer(port, cb) {
+  const server = net.createServer(cb);
+  return new Promise((resolve, reject) => {
+    server.listen(port, () => {
+      resolve(server);
+    });
+  });
+}
+
+async function startUdpServer(port, cb) {
+  const server = dgram.createSocket('udp4');
+  return new Promise((resolve, reject) => {
+    server.on('message', cb);
+    server.on('listening', () => {
+      resolve(server);
+    });
+    server.bind(port);
+  });
+}
+
+
+nsolid.start({
+  interval: 100
+});
+
+describe('StatsD status', () => {
+  before(() => {
+    this.keepAlive = setInterval(() => {
+    }, 1000);
+  });
+  after(() => {
+    clearInterval(this.keepAlive);
+  });
+  afterEach(async () => {
+    nsolid.start({
+      statsd: null
+    });
+    return waitForStatus('unconfigured');
+  });
+  it('should return unconfigured if not started', () => {
+    assert.strictEqual(nsolid.statsd.status(), 'unconfigured');
+  });
+  it('should return initializing if started', async () => {
+    assert.strictEqual(nsolid.statsd.status(), 'unconfigured');
+    nsolid.start({
+      statsd: 'udp://127.0.0.1:8125'
+    });
+
+    await waitForStatus('ready');
+  });
+  it('should be connecting if started and configured using TCP but no statsd server', async () => {
+    assert.strictEqual(nsolid.statsd.status(), 'unconfigured');
+    nsolid.start({
+      statsd: 'tcp://127.0.0.1:8125'
+    });
+    await waitForStatus('connecting');
+  });
+  it('should also work starting UDP and then TCP', async () => {
+    assert.strictEqual(nsolid.statsd.status(), 'unconfigured');
+    nsolid.start({
+      statsd: 'udp://127.0.0.1:8125'
+    });
+    await waitForStatus('ready');
+    assert.strictEqual(nsolid.statsd.tcpIp(), null);
+    assert.strictEqual(nsolid.statsd.udpIp(), '127.0.0.1:8125');
+    nsolid.start({
+      statsd: 'tcp://127.0.0.1:8125'
+    });
+    await waitForStatus('connecting');
+  });
+  it('should end up ready if started and configured using TCP with statsd server', async (t) => {
+    assert.strictEqual(nsolid.statsd.status(), 'unconfigured');
+    return startTcpServer(8125, (conn) => {
+      const recvMetrics = [];
+      this.tcpConnection = conn;
+      const rl = readline.createInterface({
+        input: conn
+      });
+
+      rl.on('line', (line) => {
+        assert.ok(line.startsWith(nsolid.statsd.format.bucket()));
+        recvMetrics.push(line.split(':')[0].split('.').pop());
+        if (recvMetrics.length === expectedMetrics.length) {
+          rl.close();
+        }
+      });
+
+      rl.on('close', () => {
+        const diff = expectedMetrics.filter((x) => !recvMetrics.includes(x));
+        assert.strictEqual(diff.length, 0);
+        this.tcpConnection.destroy();
+        this.tcpServer.close();
+      });
+    }).then((tcpServer) => {
+      return new Promise((resolve, reject) => {
+        this.tcpServer = tcpServer;
+        this.tcpServer.on('close', resolve);
+        nsolid.start({
+          statsd: 'tcp://127.0.0.1:8125'
+        });
+        return waitForStatus('ready').then(() => {
+          assert.strictEqual(nsolid.statsd.tcpIp(), '127.0.0.1:8125');
+          assert.strictEqual(nsolid.statsd.udpIp(), null);
+        });
+      });
+    });
+  });
+  it('should end up ready if started and configured using UDP with statsd server', async (t) => {
+    assert.strictEqual(nsolid.statsd.status(), 'unconfigured');
+    const bufferStream = new stream.PassThrough();
+    return startUdpServer(8125, (message) => {
+      bufferStream.write(message.toString());
+    }).then((udpServer) => {
+      const recvMetrics = [];
+      this.udpServer = udpServer;
+      const rl = readline.createInterface({
+        input: bufferStream
+      });
+
+      rl.on('line', (line) => {
+        assert.ok(line.startsWith(nsolid.statsd.format.bucket()));
+        recvMetrics.push(line.split(':')[0].split('.').pop());
+        if (recvMetrics.length === expectedMetrics.length) {
+          rl.close();
+        }
+      });
+
+      nsolid.start({
+        statsd: 'udp://127.0.0.1:8125',
+      });
+
+      return waitForStatus('ready').then(() => {
+        assert.strictEqual(nsolid.statsd.tcpIp(), null);
+        assert.strictEqual(nsolid.statsd.udpIp(), '127.0.0.1:8125');
+        return new Promise((resolve, reject) => {
+          rl.on('close', () => {
+            const diff = expectedMetrics.filter((x) => !recvMetrics.includes(x));
+            assert.strictEqual(diff.length, 0);
+            this.udpServer.close();
+            resolve();
+          });
+        });
+      });
+    });
+  });
+});

--- a/test/agents/test-statsd-format.js
+++ b/test/agents/test-statsd-format.js
@@ -1,0 +1,54 @@
+// Flags: --expose-internals
+
+'use strict';
+
+require('../common');
+const assert = require('node:assert');
+const os = require('node:os');
+const { describe, it } = require('node:test');
+const nsolid = require('nsolid');
+
+function waitForStatus(status, done) {
+  const interval = setInterval(() => {
+    if (nsolid.statsd.status() === status) {
+      clearInterval(interval);
+      done();
+    }
+  }, 10);
+}
+
+describe('format', () => {
+  it('should return the correct format values', (t, done) => {
+    assert.strictEqual(nsolid.statsd.status(), 'unconfigured');
+    nsolid.start({
+      statsd: 8125,
+      app: 'hello.goodbye.hello'
+    });
+    waitForStatus('ready', () => {
+      const info = nsolid.info();
+      const env = info.nodeEnv.replace(/\./g, '-');
+      const app = info.app.replace(/\./g, '-');
+      const hostname = os.hostname().replace(/\./g, '-');
+      const expectedBucket = `nsolid.${env}.${app}.${hostname}.${nsolid.id.substr(0, 7)}`;
+      console.log(expectedBucket);
+      assert.strictEqual(nsolid.statsd.format.bucket(), expectedBucket);
+      assert.strictEqual(nsolid.statsd.format.tags(), '');
+      assert.strictEqual(nsolid.statsd.format.counter('name', 'val'), `${expectedBucket}.name:val|c`);
+      assert.strictEqual(nsolid.statsd.format.gauge('name', 'val'), `${expectedBucket}.name:val|g`);
+      assert.strictEqual(nsolid.statsd.format.set('name', 'val'), `${expectedBucket}.name:val|s`);
+      assert.strictEqual(nsolid.statsd.format.timing('name', 'val'), `${expectedBucket}.name:val|ms`);
+      nsolid.start({
+        statsdTags: 'tag1,tag2'
+      });
+      waitForStatus('ready', () => {
+        assert.strictEqual(nsolid.statsd.format.bucket(), expectedBucket);
+        assert.strictEqual(nsolid.statsd.format.tags(), '|#tag1,tag2');
+        assert.strictEqual(nsolid.statsd.format.counter('name', 'val'), `${expectedBucket}.name:val|c|#tag1,tag2`);
+        assert.strictEqual(nsolid.statsd.format.gauge('name', 'val'), `${expectedBucket}.name:val|g|#tag1,tag2`);
+        assert.strictEqual(nsolid.statsd.format.set('name', 'val'), `${expectedBucket}.name:val|s|#tag1,tag2`);
+        assert.strictEqual(nsolid.statsd.format.timing('name', 'val'), `${expectedBucket}.name:val|ms|#tag1,tag2`);
+        done();
+      });
+    });
+  });
+});

--- a/test/agents/test-statsd-send.js
+++ b/test/agents/test-statsd-send.js
@@ -1,0 +1,155 @@
+// Flags: --expose-internals
+
+'use strict';
+
+const common = require('../common');
+const assert = require('node:assert');
+const { afterEach, describe, it } = require('node:test');
+const nsolid = require('nsolid');
+const dgram = require('dgram');
+const net = require('net');
+const readline = require('readline');
+const stream = require('stream');
+
+function waitForStatus(status, done) {
+  const interval = setInterval(() => {
+    if (nsolid.statsd.status() === status) {
+      clearInterval(interval);
+      done();
+    }
+  }, 10);
+}
+
+async function startTcpServer(port, cb) {
+  const server = net.createServer(cb);
+  return new Promise((resolve, reject) => {
+    server.listen(port, () => {
+      resolve(server);
+    });
+  });
+}
+
+async function startUdpServer(port, cb) {
+  const server = dgram.createSocket('udp4');
+  return new Promise((resolve, reject) => {
+    server.on('message', cb);
+    server.on('listening', () => {
+      resolve(server);
+    });
+    server.bind(port);
+  });
+}
+
+describe('sending custom metrics', () => {
+  afterEach((t, done) => {
+    nsolid.start({
+      statsd: null
+    });
+    waitForStatus('unconfigured', done);
+  });
+  it('should work with TCP', async (t) => {
+    assert.strictEqual(nsolid.statsd.status(), 'unconfigured');
+    return startTcpServer(8125, (conn) => {
+      let times = 0;
+      this.tcpConnection = conn;
+      const rl = readline.createInterface({
+        input: conn
+      });
+
+      rl.on('line', (line) => {
+        assert.ok(line.startsWith(nsolid.statsd.format.bucket()));
+        switch (times++) {
+          case 0:
+            assert.ok(line.endsWith('.name:val|c'));
+            break;
+          case 1:
+            assert.ok(line.endsWith('.name:val|g'));
+            break;
+          case 2:
+            assert.ok(line.endsWith('.name:val|s'));
+            break;
+          case 3:
+            assert.ok(line.endsWith('.name:val|ms'));
+            rl.close();
+            break;
+          default:
+            assert.fail();
+        }
+      });
+
+      rl.on('close', () => {
+        this.tcpConnection.destroy();
+        this.tcpServer.close();
+      });
+    }).then((tcpServer) => {
+      return new Promise((resolve, reject) => {
+        this.tcpServer = tcpServer;
+        this.tcpServer.on('close', resolve);
+        nsolid.start({
+          statsd: 'tcp://127.0.0.1:8125'
+        });
+        waitForStatus('ready', common.mustCall(() => {
+          assert.strictEqual(nsolid.statsd.tcpIp(), '127.0.0.1:8125');
+          assert.strictEqual(nsolid.statsd.udpIp(), null);
+          nsolid.statsd.counter('name', 'val');
+          nsolid.statsd.gauge('name', 'val');
+          nsolid.statsd.set('name', 'val');
+          nsolid.statsd.timing('name', 'val');
+        }));
+      });
+    });
+  });
+  it('should work with UDP', async (t) => {
+    assert.strictEqual(nsolid.statsd.status(), 'unconfigured');
+    const bufferStream = new stream.PassThrough();
+    return startUdpServer(8125, (message) => {
+      bufferStream.write(message.toString());
+    }).then((udpServer) => {
+      return new Promise((resolve, reject) => {
+        let times = 0;
+        this.udpServer = udpServer;
+        const rl = readline.createInterface({
+          input: bufferStream
+        });
+
+        rl.on('line', (line) => {
+          assert.ok(line.startsWith(nsolid.statsd.format.bucket()));
+          switch (times++) {
+            case 0:
+              assert.ok(line.endsWith('.name:val|c'));
+              break;
+            case 1:
+              assert.ok(line.endsWith('.name:val|g'));
+              break;
+            case 2:
+              assert.ok(line.endsWith('.name:val|s'));
+              break;
+            case 3:
+              assert.ok(line.endsWith('.name:val|ms'));
+              rl.close();
+              break;
+            default:
+              assert.fail();
+          }
+        });
+
+        rl.on('close', () => {
+          this.udpServer.close();
+          resolve();
+        });
+
+        nsolid.start({
+          statsd: 'udp://127.0.0.1:8125'
+        });
+        waitForStatus('ready', common.mustCall(() => {
+          assert.strictEqual(nsolid.statsd.tcpIp(), null);
+          assert.strictEqual(nsolid.statsd.udpIp(), '127.0.0.1:8125');
+          nsolid.statsd.counter('name', 'val');
+          nsolid.statsd.gauge('name', 'val');
+          nsolid.statsd.set('name', 'val');
+          nsolid.statsd.timing('name', 'val');
+        }));
+      });
+    });
+  });
+});


### PR DESCRIPTION
```
src: don't start StatsD agent if statsd is null

```
```

agents: fix StatsDTcp destruction

Add an `internal_state_` member variable which allows us to track
`uv_req_t` completions, so we can avoid to actually destroy the instance
before they are completed.
The API is changed so the destructor is private and to destroy the
instance a new public `close_and_delete()` method has been added.

```
```

agents: fix Status binding

Return "unconfigured" directly if there's no `StatsDAgent` instance
running just yet. To accomplpish this the `is_running_` atomic needs to
be public.

```
```

agents: move to Initializing before setting Hooks

This way if an env_creation event is received, the StatsDAgent would
already be in the correct state to handle it.

```
```

agents: synchronize status in StatsDagent::do_stop

```
```

agents: stop the agent only if last config fails

```
```

agents: reset addr_index_ on connector setup

```
```

agents: fix exit condition on status_command_cb_

```
```

agents,test: add StatsDAgent tests

```
```

agents: clear env_metrics_map_ on destruction

This way, when starting/stopping/starting the agent, we will be able to
keep track of the current JS threads.

```