### PR TITLE
src: include sync stop for heap object tracking

### DIFF
--- a/src/nsolid.cc
+++ b/src/nsolid.cc
@@ -538,6 +538,13 @@ int Snapshot::StopTrackingHeapObjects(SharedEnvInst envinst) {
   return NSolidHeapSnapshot::Inst()->StopTrackingHeapObjects(envinst);
 }
 
+int Snapshot::StopTrackingHeapObjectsSync(SharedEnvInst envinst) {
+  if (envinst == nullptr)
+    return UV_ESRCH;
+
+  return NSolidHeapSnapshot::Inst()->StopTrackingHeapObjectsSync(envinst);
+}
+
 int Snapshot::get_snapshot_(SharedEnvInst envinst,
                             bool redacted,
                             void* data,

--- a/src/nsolid.h
+++ b/src/nsolid.h
@@ -1005,6 +1005,16 @@ class NODE_EXTERN Snapshot {
    */
   static int StopTrackingHeapObjects(SharedEnvInst envinst);
 
+  /**
+   * @brief same as TakeSnapshot but stops tracking heap objects in the heap
+   * profiler synchronously.
+   *
+   * @param envinst SharedEnvInst of thread to take the snapshot from.
+   * @return NSOLID_E_SUCCESS in case of success or a different NSOLID_E_
+   * error value otherwise.
+   */
+  static int StopTrackingHeapObjectsSync(SharedEnvInst envinst);
+
  private:
   static int start_tracking_heap_objects_(SharedEnvInst envinst,
                                           bool redacted,

--- a/src/nsolid/nsolid_heap_snapshot.h
+++ b/src/nsolid/nsolid_heap_snapshot.h
@@ -20,9 +20,15 @@ namespace nsolid {
 
 class NSolidHeapSnapshot {
  public:
+  enum HeapSnapshotFlags {
+    kFlagNone = 0,
+    kFlagIsTrackingHeapObjects = 1 << 0,
+    kFlagIsDone = 1 << 1
+  };
+
   struct HeapSnapshotStor {
     bool redacted;
-    bool is_tracking_heapobjects_;
+    uint32_t flags;
     uint64_t snapshot_id;
     Snapshot::snapshot_proxy_sig cb;
     internal::user_data data;

--- a/test/addons/nsolid-track-heap-objects/binding.cc
+++ b/test/addons/nsolid-track-heap-objects/binding.cc
@@ -6,27 +6,77 @@
 #include <assert.h>
 #include <map>
 
+using v8::Context;
+using v8::Function;
 using v8::FunctionCallbackInfo;
+using v8::Global;
+using v8::HandleScope;
 using v8::Integer;
+using v8::Isolate;
+using v8::Local;
+using v8::NewStringType;
 using v8::Number;
+using v8::String;
 using v8::Value;
 
-std::map<uint64_t, std::string> snapshots;
+struct Stor {
+  std::string profile;
+  Global<Function> cb;
+};
 
-static void got_snapshot(int status,
-                         std::string snapshot,
-                         uint64_t thread_id) {
-  assert(status == 0);
-  snapshots[thread_id] += snapshot;
+std::map<uint64_t, Stor> profiles;
+uv_mutex_t profiles_map_lock;
+
+static void profile_cb(node::nsolid::SharedEnvInst envinst, int status) {
+  uint64_t thread_id = node::nsolid::GetThreadId(envinst);
+  uv_mutex_lock(&profiles_map_lock);
+  auto it = profiles.find(thread_id);
+  assert(it != profiles.end());
+  Isolate* isolate = Isolate::GetCurrent();
+  HandleScope scope(isolate);
+  Local<Context> context = isolate->GetCurrentContext();
+  Context::Scope context_scope(context);
+  Local<Function> cb = it->second.cb.Get(isolate);
+  Local<Value> argv[] = {
+    Integer::New(isolate, status),
+    String::NewFromUtf8(
+      isolate,
+      it->second.profile.c_str(),
+      NewStringType::kNormal).ToLocalChecked()
+  };
+
+  profiles.erase(it);
+  uv_mutex_unlock(&profiles_map_lock);
+  cb->Call(context, Undefined(isolate), 2, argv);
 }
 
-static void started_profiler(int status, std::string json, uint64_t thread_id) {
+static void got_profile(int status,
+                        std::string profile,
+                        uint64_t thread_id) {
   assert(status == 0);
+  uv_mutex_lock(&profiles_map_lock);
+  auto it = profiles.find(thread_id);
+  assert(it != profiles.end());
+  if (profile.empty()) {
+    if (it->second.cb.IsEmpty()) {
+      profiles.erase(it);
+    } else {
+      node::nsolid::SharedEnvInst envinst = node::nsolid::GetEnvInst(thread_id);
+      assert(0 == node::nsolid::RunCommand(envinst,
+                                           node::nsolid::CommandType::EventLoop,
+                                           profile_cb,
+                                           status));
+    }
+  } else {
+    it->second.profile += profile;
+  }
+
+  uv_mutex_unlock(&profiles_map_lock);
 }
 
 static void StartTrackingHeapObjectsBinding(
     const FunctionCallbackInfo<Value>& args) {
-  v8::HandleScope handle_scope(args.GetIsolate());
+  HandleScope handle_scope(args.GetIsolate());
   // thread_id
   assert(args[0]->IsUint32());
   // Redacted heap snapshot
@@ -35,6 +85,9 @@ static void StartTrackingHeapObjectsBinding(
   assert(args[2]->IsBoolean());
   // Stop after this many milliseconds
   assert(args[3]->IsNumber());
+  if (args.Length() > 4) {
+    assert(args[4]->IsFunction());
+  }
 
   uint64_t thread_id = args[0].As<Number>()->Value();
   bool redacted = args[1]->BooleanValue(args.GetIsolate());
@@ -42,18 +95,35 @@ static void StartTrackingHeapObjectsBinding(
   uint64_t duration = static_cast<uint64_t>(
       args[3]->NumberValue(args.GetIsolate()->GetCurrentContext()).FromJust());
 
+  uv_mutex_lock(&profiles_map_lock);
+  auto pair = profiles.emplace(thread_id, Stor());
+  if (args.Length() > 4) {
+    pair.first->second.cb.Reset(args.GetIsolate(), args[4].As<Function>());
+  }
+  uv_mutex_unlock(&profiles_map_lock);
+
   int ret = node::nsolid::Snapshot::StartTrackingHeapObjects(
       node::nsolid::GetEnvInst(thread_id),
       redacted,
       track_allocations,
       duration,
-      started_profiler,
+      got_profile,
       thread_id);
+  if (ret != 0) {
+    if (pair.second) {
+      uv_mutex_lock(&profiles_map_lock);
+      profiles.erase(thread_id);
+      uv_mutex_unlock(&profiles_map_lock);
+    }
+  } else {
+    assert(pair.second);
+  }
+
   args.GetReturnValue().Set(Integer::New(args.GetIsolate(), ret));
 }
 
 static void StopTrackingHeapObjects(const FunctionCallbackInfo<Value>& args) {
-  v8::HandleScope handle_scope(args.GetIsolate());
+  HandleScope handle_scope(args.GetIsolate());
   // thread_id
   assert(args[0]->IsUint32());
 
@@ -66,7 +136,7 @@ static void StopTrackingHeapObjects(const FunctionCallbackInfo<Value>& args) {
 
 static void StopTrackingHeapObjectsSync(
     const FunctionCallbackInfo<Value>& args) {
-  v8::HandleScope handle_scope(args.GetIsolate());
+  HandleScope handle_scope(args.GetIsolate());
   // thread_id
   assert(args[0]->IsUint32());
 
@@ -78,9 +148,7 @@ static void StopTrackingHeapObjectsSync(
 }
 
 static void at_exit_cb() {
-  for (const auto& pair : snapshots) {
-    assert(pair.second.size() > 0);
-  }
+  uv_mutex_destroy(&profiles_map_lock);
 }
 
 NODE_MODULE_INIT(/* exports, module, context */) {
@@ -91,6 +159,7 @@ NODE_MODULE_INIT(/* exports, module, context */) {
       exports, "stopTrackingHeapObjectsSync", StopTrackingHeapObjectsSync);
   node::nsolid::SharedEnvInst envinst = node::nsolid::GetLocalEnvInst(context);
   if (node::nsolid::IsMainThread(envinst)) {
+    assert(0 == uv_mutex_init(&profiles_map_lock));
     atexit(at_exit_cb);
   }
 }

--- a/test/addons/nsolid-track-heap-objects/binding.cc
+++ b/test/addons/nsolid-track-heap-objects/binding.cc
@@ -64,6 +64,19 @@ static void StopTrackingHeapObjects(const FunctionCallbackInfo<Value>& args) {
   args.GetReturnValue().Set(ret);
 }
 
+static void StopTrackingHeapObjectsSync(
+    const FunctionCallbackInfo<Value>& args) {
+  v8::HandleScope handle_scope(args.GetIsolate());
+  // thread_id
+  assert(args[0]->IsUint32());
+
+  uint64_t thread_id = args[0].As<Number>()->Value();
+
+  int ret = node::nsolid::Snapshot::StopTrackingHeapObjectsSync(
+      node::nsolid::GetEnvInst(thread_id));
+  args.GetReturnValue().Set(ret);
+}
+
 static void at_exit_cb() {
   for (const auto& pair : snapshots) {
     assert(pair.second.size() > 0);
@@ -74,6 +87,8 @@ NODE_MODULE_INIT(/* exports, module, context */) {
   NODE_SET_METHOD(
       exports, "startTrackingHeapObjects", StartTrackingHeapObjectsBinding);
   NODE_SET_METHOD(exports, "stopTrackingHeapObjects", StopTrackingHeapObjects);
+  NODE_SET_METHOD(
+      exports, "stopTrackingHeapObjectsSync", StopTrackingHeapObjectsSync);
   node::nsolid::SharedEnvInst envinst = node::nsolid::GetLocalEnvInst(context);
   if (node::nsolid::IsMainThread(envinst)) {
     atexit(at_exit_cb);

--- a/test/addons/nsolid-track-heap-objects/nsolid-track-heap-objects.js
+++ b/test/addons/nsolid-track-heap-objects/nsolid-track-heap-objects.js
@@ -44,7 +44,7 @@ setTimeout(() => {
   er = binding.startTrackingHeapObjects(threadId, false, false, 10);
   assert.strictEqual(er, UV_EEXIST);
 
-  er = binding.stopTrackingHeapObjects(threadId);
+  er = binding.stopTrackingHeapObjectsSync(threadId);
   assert.strictEqual(er, 0);
   setTimeout(() => {
     er = binding.stopTrackingHeapObjects(threadId);


### PR DESCRIPTION
This patch includes `StopTrackingHeapObjects` synchronously. NSolid will
grab all in-progress profiles on exit.

Also, this path will convert the tracker stopper serialization async.

PR-URL: https://github.com/nodesource/nsolid/pull/92