### PR TITLE
lib: add nsolid JS API for heap profiling

### DIFF
--- a/agents/zmq/lib/agent.js
+++ b/agents/zmq/lib/agent.js
@@ -3,14 +3,19 @@
 const {
   ERR_NSOLID_CPU_PROFILE_START,
   ERR_NSOLID_CPU_PROFILE_STOP,
+  ERR_NSOLID_HEAP_PROFILE_START,
+  ERR_NSOLID_HEAP_PROFILE_STOP,
   ERR_NSOLID_HEAP_SNAPSHOT,
 } = require('internal/errors').codes;
 const {
+  validateBoolean,
   validateFunction,
   validateNumber,
 } = require('internal/validators');
 
-module.exports = ({ profile: _profile,
+module.exports = ({ heapProfile: _heapProfile,
+                    heapProfileEnd: _heapProfileEnd,
+                    profile: _profile,
                     profileEnd: _profileEnd,
                     snapshot: _snapshot,
                     start,
@@ -112,6 +117,108 @@ module.exports = ({ profile: _profile,
   };
 
   /**
+   * Executes Heap-profiling of the current JS thread for `timeout` seconds and
+   * sends the data to the console once it's done. It does not return until the
+   * profiling has started or it has failed.
+   * @param {number} [timeout=600000]
+   * @param {trackAllocations} [trackAllocations=false]
+   * @param {heapProfileCallback} [cb] called when the profile has started or there
+   * has been an error.
+   * @example
+   * const nsolid = require('nsolid');
+   * // async version
+   * nsolid.heapProfile(600, true, (err) => {
+   *   if(!err) {
+   *     console.log('Profile started!');
+   *   }
+   * });
+   * // sync version
+   * try {
+   *   // starts profiling for 600000 seconds without tracking allocations
+   *   nsolid.heapProfile();
+   * } catch (err) {
+   *   // In case an error happens
+   * }
+   * @throws Will throw an error if an error happens and no callback was passed.
+   * @function profile
+   * @memberof module:nsolid
+   */
+  const heapProfile = (timeout, trackAllocations, cb) => {
+    if (typeof timeout === 'function') {
+      cb = timeout;
+      timeout = null;
+      trackAllocations = false;
+    } else if (typeof trackAllocations === 'function') {
+      cb = trackAllocations;
+      trackAllocations = false;
+    }
+
+    timeout = timeout || 600000;
+    trackAllocations = trackAllocations || false;
+    validateNumber(timeout, 'timeout');
+    validateBoolean(trackAllocations, 'trackAllocations');
+
+    if (cb !== undefined) {
+      validateFunction(cb, 'heapProfileCallback');
+    }
+
+    const status = _heapProfile(timeout, trackAllocations);
+    let err;
+    if (status !== 0) {
+      err = new ERR_NSOLID_HEAP_PROFILE_START();
+      err.code = status;
+    }
+
+    if (cb) {
+      process.nextTick(() => cb(err));
+    } else if (err) {
+      throw err;
+    }
+  };
+
+  /**
+   * Stops the running Heap-profile in the current JS thread (if any)
+   * @param {heapProfileEndCallback} [cb] called when the profile has started or
+   * there has been an error.
+   * @example
+   * const nsolid = require('nsolid');
+   * // async version
+   * nsolid.heapProfile(600, (err) => {
+   *   if(!err) {
+   *     console.log('Profile started!');
+   *     setTimeout(() => {
+   *       nsolid.heapProfileEnd((err) => {
+   *         if (!err) {
+   *           console.log('Profile ended!');
+   *         }}
+   *       });
+   *     }, 1000);
+   *   }
+   * });
+   * @throws Will throw an error if an error happens and no callback was passed.
+   * @function heapProfileEnd
+   * @memberof module:nsolid
+   */
+  const heapProfileEnd = (cb) => {
+    if (cb !== undefined) {
+      validateFunction(cb, 'heapProfileEndCallback');
+    }
+
+    const status = _heapProfileEnd();
+    let err;
+    if (status !== 0) {
+      err = new ERR_NSOLID_HEAP_PROFILE_STOP();
+      err.code = status;
+    }
+
+    if (cb) {
+      process.nextTick(() => cb(err));
+    } else if (err) {
+      throw err;
+    }
+  };
+
+  /**
    * It generates a heap snapshot of the current JS thread and sends it to the
    * console. It does not return until the snapshot has been generated or an
    * error has happened.
@@ -155,6 +262,8 @@ module.exports = ({ profile: _profile,
   };
 
   return {
+    heapProfile,
+    heapProfileEnd,
     profile,
     profileEnd,
     snapshot,

--- a/doc/api/errors.md
+++ b/doc/api/errors.md
@@ -3601,6 +3601,18 @@ Error when trying to respond to a custom command more than once.
 
 Out of memory error when handling a custom command.
 
+<a id="ERR_NSOLID_HEAP_PROFILE_START"></a>
+
+### `ERR_NSOLID_HEAP_PROFILE_START`
+
+Error when trying to start taking a heap profile with the JS API.
+
+<a id="ERR_NSOLID_HEAP_PROFILE_STOP"></a>
+
+### `ERR_NSOLID_HEAP_PROFILE_STOP`
+
+Error when trying to stop a heap profile being taken with the JS API.
+
 <a id="ERR_NSOLID_HEAP_SNAPSHOT"></a>
 
 ### `ERR_NSOLID_HEAP_SNAPSHOT`

--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -1598,6 +1598,10 @@ E('ERR_NSOLID_CUSTOM_COMMAND_ALREADY_RETURNED',
   'custom command `%s` (%s) already returned', Error);
 E('ERR_NSOLID_CUSTOM_COMMAND_OUT_OF_MEMORY',
   'out of memory custom command `%s` (%s) error', Error);
+E('ERR_NSOLID_HEAP_PROFILE_START',
+  'Heap profile could not be started', Error);
+E('ERR_NSOLID_HEAP_PROFILE_STOP',
+  'Heap profile could not be stopped', Error);
 E('ERR_NSOLID_HEAP_SNAPSHOT',
   'Heap snapshot could not be generated', Error);
 E('ERR_NSOLID_OTEL_API_ALREADY_REGISTERED',

--- a/lib/nsolid.js
+++ b/lib/nsolid.js
@@ -14,6 +14,11 @@ const { addPackage, updatePackage, packageList, packagePaths } =
   require('internal/nsolid_module');
 const { existsSync, readdirSync, realpathSync } = require('fs');
 const { dirname, relative, resolve, sep, toNamespacedPath } = require('path');
+const { Readable } = require('stream');
+const {
+  validateBoolean,
+  validateNumber,
+} = require('internal/validators');
 
 const {
   ArrayIsArray,
@@ -33,6 +38,7 @@ const statsd = require('internal/agents/statsd/lib/nsolid');
 const zmq = require('internal/agents/zmq/lib/nsolid');
 const {
   codes: {
+    ERR_NSOLID_HEAP_PROFILE_START,
     ERR_INVALID_ARG_TYPE,
   },
 } = require('internal/errors');
@@ -115,6 +121,9 @@ ObjectAssign(start, {
     timing: statsd.timing,
     format: statsd.format,
   },
+  heapProfileStream,
+  heapProfile: zmq.heapProfile,
+  heapProfileEnd: zmq.heapProfileEnd,
   profile: zmq.profile,
   profileEnd: zmq.profileEnd,
   on,
@@ -325,6 +334,65 @@ function packages(cb) {
   if (typeof cb !== 'function')
     return a;
   process.nextTick(() => cb(null, a));
+}
+
+
+/**
+ * Starts a heap profile in a specific JS thread and returns a readable stream
+ * of the profile data.
+ * @param {number} threadId - The ID of the thread for which to start the heap profile.
+ * @param {number} duration - The duration in milliseconds for which to run the heap profile.
+ * @param {boolean} trackAllocations - Whether to track allocations during the heap profile.
+ * @example
+ * const nsolid = require('nsolid');
+ * const threadId = 1;
+ * const duration = 5000; // 5 seconds
+ * const trackAllocations = true;
+ * const heapProfileStream = nsolid.heapProfileStream(threadId, duration, trackAllocations);
+ * heapProfileStream.on('data', (data) => {
+ *   console.log('Heap Profile Data:', data);
+ * });
+ * heapProfileStream.on('error', (err) => {
+ *   console.error('Error:', err);
+ * });
+ * @returns {Readable} A readable stream of the heap profile data. It emits an
+ * {ERR_NSOLID_HEAP_PROFILE_START} If there is an error starting the heap profile.
+ * @alias module:nsolid.heapProfileStream
+ */
+function heapProfileStream(threadId, duration, trackAllocations) {
+  validateNumber(threadId, 'threadId');
+  validateNumber(duration, 'duration');
+  validateBoolean(trackAllocations, 'trackAllocations');
+  const redacted = getConfig('redactSnapshots') || false;
+  const readable = new Readable({
+    read() {
+    },
+    destroy(err, cb) {
+      binding.heapProfileEnd(threadId);
+      if (typeof cb === 'function')
+        cb(err);
+    },
+  });
+
+  const ret = binding.heapProfile(threadId, duration, trackAllocations, redacted, (status, data) => {
+    if (status !== 0) {
+      const err = new ERR_NSOLID_HEAP_PROFILE_START();
+      err.code = status;
+      readable.destroy(err);
+    } else if (data === null) {
+      readable.push(null);
+    } else {
+      readable.push(data);
+    }
+  });
+
+  if (ret !== 0) {
+    const err = new ERR_NSOLID_HEAP_PROFILE_START();
+    err.code = ret;
+    readable.destroy(err);
+  }
+
+  return readable;
 }
 
 

--- a/test/parallel/test-nsolid-heap-profile-stream.js
+++ b/test/parallel/test-nsolid-heap-profile-stream.js
@@ -1,0 +1,69 @@
+// Flags: --expose-internals
+'use strict';
+
+const common = require('../common');
+const assert = require('assert');
+const nsolid = require('nsolid');
+const { internalBinding } = require('internal/test/binding');
+
+const {
+  UV_ESRCH,
+} = internalBinding('uv');
+
+[ true, 'foo', /a/, Symbol()].forEach((arg) => {
+  assert.throws(
+    () => {
+      nsolid.heapProfileStream(arg);
+    },
+    {
+      message: 'The "threadId" argument must be of type number.' +
+               common.invalidArgTypeHelper(arg),
+      code: 'ERR_INVALID_ARG_TYPE'
+    }
+  );
+});
+
+[ true, 'foo', /a/, Symbol()].forEach((arg) => {
+  assert.throws(
+    () => {
+      nsolid.heapProfileStream(0, arg);
+    },
+    {
+      message: 'The "duration" argument must be of type number.' +
+               common.invalidArgTypeHelper(arg),
+      code: 'ERR_INVALID_ARG_TYPE'
+    }
+  );
+});
+
+[ 'foo', 5, /a/, Symbol()].forEach((arg) => {
+  assert.throws(
+    () => {
+      nsolid.heapProfileStream(0, 5, arg);
+    },
+    {
+      message: 'The "trackAllocations" argument must be of type boolean.' +
+               common.invalidArgTypeHelper(arg),
+      code: 'ERR_INVALID_ARG_TYPE'
+    }
+  );
+});
+
+{
+  const stream = nsolid.heapProfileStream(10, 12000, true);
+  stream.on('error', common.mustCall((err) => {
+    assert.strictEqual(err.message, 'Heap profile could not be started');
+    assert.strictEqual(err.code, UV_ESRCH);
+  }));
+}
+
+{
+  let profile = '';
+  const stream = nsolid.heapProfileStream(0, 1200, true);
+  stream.on('data', (data) => {
+    profile += data;
+  });
+  stream.on('end', common.mustCall(() => {
+    assert(JSON.parse(profile));
+  }));
+}

--- a/test/parallel/test-nsolid-heap-profile.js
+++ b/test/parallel/test-nsolid-heap-profile.js
@@ -1,0 +1,130 @@
+'use strict';
+
+const common = require('../common');
+const assert = require('assert');
+const nsolid = require('nsolid');
+
+[ true, 'foo', /a/, Symbol()].forEach((arg) => {
+  assert.throws(
+    () => {
+      nsolid.heapProfile(arg);
+    },
+    {
+      message: 'The "timeout" argument must be of type number.' +
+               common.invalidArgTypeHelper(arg),
+      code: 'ERR_INVALID_ARG_TYPE'
+    }
+  );
+});
+
+[ 'foo', 5, /a/, Symbol()].forEach((arg) => {
+  assert.throws(
+    () => {
+      nsolid.heapProfile(5, arg);
+    },
+    {
+      message: 'The "trackAllocations" argument must be of type boolean.' +
+               common.invalidArgTypeHelper(arg),
+      code: 'ERR_INVALID_ARG_TYPE'
+    }
+  );
+});
+
+[ null, false, true, 'foo', 5, /a/, Symbol()].forEach((arg) => {
+  assert.throws(
+    () => {
+      nsolid.heapProfile(5, true, arg);
+    },
+    {
+      message: 'The "heapProfileCallback" argument must be of type function.' +
+               common.invalidArgTypeHelper(arg),
+      code: 'ERR_INVALID_ARG_TYPE'
+    }
+  );
+});
+
+[ null, false, true, 'foo', 5, /a/, Symbol()].forEach((arg) => {
+  assert.throws(
+    () => {
+      nsolid.heapProfileEnd(arg);
+    },
+    {
+      message: 'The "heapProfileEndCallback" argument must be of type function.' +
+               common.invalidArgTypeHelper(arg),
+      code: 'ERR_INVALID_ARG_TYPE'
+    }
+  );
+});
+
+// profile() should return error if not connected to a console
+assert.throws(
+  () => {
+    nsolid.heapProfile();
+  },
+  {
+    message: 'Heap profile could not be started'
+  }
+);
+
+nsolid.heapProfile(common.mustCall((err) => {
+  assert.notStrictEqual(err.code, 0);
+  assert.strictEqual(err.message, 'Heap profile could not be started');
+}));
+
+// Configure the console so the `profile()` call may succeed
+nsolid.start({
+  command: 'localhost:9001',
+  data: 'localhost:9002'
+});
+
+setTimeout(() => {
+  // profile() should return an error if ongoing profile
+  assert.strictEqual(nsolid.heapProfile(), undefined);
+  assert.throws(
+    () => {
+      nsolid.heapProfile();
+    },
+    {
+      message: 'Heap profile could not be started'
+    }
+  );
+
+  nsolid.heapProfile(common.mustCall((err) => {
+    assert.notStrictEqual(err.code, 0);
+    assert.strictEqual(err.message, 'Heap profile could not be started');
+  }));
+  assert.strictEqual(nsolid.heapProfileEnd(), undefined);
+
+  setTimeout(() => {
+    // profileEnd() should return an error if no ongoing profile
+    assert.throws(
+      () => {
+        nsolid.heapProfileEnd();
+      },
+      {
+        message: 'Heap profile could not be stopped'
+      }
+    );
+
+    nsolid.heapProfileEnd(common.mustCall((err) => {
+      assert.notStrictEqual(err.code, 0);
+      assert.strictEqual(err.message, 'Heap profile could not be stopped');
+      // The same with callback versions
+      // profile() should return an error if ongoing profile
+      nsolid.heapProfile(common.mustSucceed(() => {
+        nsolid.heapProfile(common.mustCall((err) => {
+          assert.notStrictEqual(err.code, 0);
+          assert.strictEqual(err.message, 'Heap profile could not be started');
+          nsolid.heapProfileEnd(common.mustSucceed(() => {
+            // profileEnd() should return an error if no ongoing profile
+            nsolid.heapProfileEnd(common.mustCall((err) => {
+              assert.notStrictEqual(err.code, 0);
+              assert.strictEqual(err.message,
+                                 'Heap profile could not be stopped');
+            }));
+          }));
+        }));
+      }));
+    }));
+  }, 100);
+}, 100);


### PR DESCRIPTION
It involves two different set of API's.

The first one, is the classic `N|Solid` api which will create a profile and send it to the Console. It consists of the following methods:
- `heapProfile()` and `heapProfileEnd()`.

The second allows to retrieve the heap profile via a `Readable` using the following method:

```
const stream = heapProfileStream(threadId, duration, trackAllocations);
```

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
