### PR TITLE
A bit of refactoring of NSolidHeapSnapshot

### DIFF
--- a/src/nsolid.cc
+++ b/src/nsolid.cc
@@ -527,7 +527,7 @@ int Snapshot::start_tracking_heap_objects_(SharedEnvInst envinst,
                                            uint64_t duration,
                                            internal::user_data data,
                                            snapshot_proxy_sig proxy) {
-  return NSolidHeapSnapshot::Inst()->StartTrackingHeapObjects(
+  return EnvList::Inst()->HeapSnapshot()->StartTrackingHeapObjects(
       envinst, redacted, trackAllocations, duration, std::move(data), proxy);
 }
 
@@ -535,14 +535,14 @@ int Snapshot::StopTrackingHeapObjects(SharedEnvInst envinst) {
   if (envinst == nullptr)
     return UV_ESRCH;
 
-  return NSolidHeapSnapshot::Inst()->StopTrackingHeapObjects(envinst);
+  return EnvList::Inst()->HeapSnapshot()->StopTrackingHeapObjects(envinst);
 }
 
 int Snapshot::StopTrackingHeapObjectsSync(SharedEnvInst envinst) {
   if (envinst == nullptr)
     return UV_ESRCH;
 
-  return NSolidHeapSnapshot::Inst()->StopTrackingHeapObjectsSync(envinst);
+  return EnvList::Inst()->HeapSnapshot()->StopTrackingHeapObjectsSync(envinst);
 }
 
 int Snapshot::get_snapshot_(SharedEnvInst envinst,
@@ -553,7 +553,7 @@ int Snapshot::get_snapshot_(SharedEnvInst envinst,
   if (envinst == nullptr)
     return UV_ESRCH;
 
-  return NSolidHeapSnapshot::Inst()->
+  return EnvList::Inst()->HeapSnapshot()->
     GetHeapSnapshot(envinst, redacted, data, proxy, deleter);
 }
 

--- a/src/nsolid/nsolid_api.cc
+++ b/src/nsolid/nsolid_api.cc
@@ -5,7 +5,6 @@
 #include "nsolid_cpu_profiler.h"
 #include "otlp/src/otlp_agent.h"
 #include "statsd/src/statsd_agent.h"
-#include "nsuv-inl.h"
 #include "util.h"
 #include "env-inl.h"
 #include "uv.h"
@@ -969,7 +968,7 @@ void EnvList::RemoveEnv(Environment* env) {
   // End any pending CPU profiles. This has to be done before removing the
   // EnvList from env_map_ so the checks in StopProfilingSync() pass.
   NSolidCpuProfiler::Inst()->StopProfilingSync(envinst_sp);
-  NSolidHeapSnapshot::Inst()->StopTrackingHeapObjectsSync(envinst_sp);
+  heap_snapshot_.StopTrackingHeapObjects(envinst_sp);
 
   // Remove the GC prologue and epilogue callbacks just to be safe.
   envinst_sp->env()->isolate()->RemoveGCPrologueCallback(

--- a/src/nsolid/nsolid_api.h
+++ b/src/nsolid/nsolid_api.h
@@ -17,9 +17,10 @@
 #include "node.h"
 #include "node_snapshotable.h"
 #include "nsolid.h"
-#include "../../deps/nsuv/include/nsuv-inl.h"
-#include "nsolid_util.h"
+#include "nsuv-inl.h"
+#include "nsolid_heap_snapshot.h"
 #include "nsolid_trace.h"
+#include "nsolid_util.h"
 #include "spinlock.h"
 #include "thread_safe.h"
 #include "v8.h"
@@ -567,6 +568,8 @@ class EnvList {
                        void* data);
   void RemoveMetricsStreamHook(TSList<MetricsStreamHookStor>::iterator it);
 
+  NSolidHeapSnapshot* HeapSnapshot() { return &heap_snapshot_; }
+
  private:
   friend class EnvInst;
   friend class Metrics;
@@ -679,6 +682,8 @@ class EnvList {
   DispatchQueue<tracing::SpanItem> span_item_q_;
 
   double time_origin_;
+
+  NSolidHeapSnapshot heap_snapshot_;
 };
 
 

--- a/src/nsolid/nsolid_heap_snapshot.cc
+++ b/src/nsolid/nsolid_heap_snapshot.cc
@@ -1,4 +1,7 @@
 #include "nsolid_heap_snapshot.h"
+#include "asserts-cpp/asserts.h"
+#include "nsolid_api.h"
+#include "nsolid_output_stream.h"
 
 namespace node {
 namespace nsolid {

--- a/src/nsolid/nsolid_heap_snapshot.h
+++ b/src/nsolid/nsolid_heap_snapshot.h
@@ -3,17 +3,14 @@
 
 #if defined(NODE_WANT_INTERNALS) && NODE_WANT_INTERNALS
 
-#include <v8.h>
-#include <v8-profiler.h>
-#include <nsolid/nsolid_api.h>
-#include <nsolid/nsolid_output_stream.h>
 #include <atomic>
-#include <new>
-#include <set>
-#include <tuple>
+#include <map>
+#include <string>
 
-#include "asserts-cpp/asserts.h"
 #include "nlohmann/json.hpp"
+#include "nsolid.h"
+#include "nsolid_util.h"
+#include "nsuv-inl.h"
 
 namespace node {
 namespace nsolid {

--- a/src/nsolid/nsolid_heap_snapshot.h
+++ b/src/nsolid/nsolid_heap_snapshot.h
@@ -33,7 +33,9 @@ class NSolidHeapSnapshot {
 
   NSOLID_DELETE_UNUSED_CONSTRUCTORS(NSolidHeapSnapshot)
 
-  static NSolidHeapSnapshot* Inst();
+  NSolidHeapSnapshot();
+  ~NSolidHeapSnapshot();
+
 
   int GetHeapSnapshot(SharedEnvInst envinst,
                       bool redacted,
@@ -53,9 +55,6 @@ class NSolidHeapSnapshot {
   int StopTrackingHeapObjectsSync(SharedEnvInst envinst);
 
  private:
-  NSolidHeapSnapshot();
-  ~NSolidHeapSnapshot();
-
   static void start_tracking_heapobjects(SharedEnvInst envinst,
                                          bool trackAllocations,
                                          uint64_t duration,
@@ -73,7 +72,8 @@ class NSolidHeapSnapshot {
 
   static void snapshot_cb(uint64_t thread_id,
                           int status,
-                          const std::string& snapshot);
+                          const std::string& snapshot,
+                          NSolidHeapSnapshot* snapshotter);
 
   std::map<uint64_t, HeapSnapshotStor> threads_running_snapshots_;
   nsuv::ns_mutex in_progress_heap_snapshots_;

--- a/src/nsolid/nsolid_output_stream.h
+++ b/src/nsolid/nsolid_output_stream.h
@@ -30,7 +30,7 @@ enum ErrorType {
 template <class Data, typename V8Object>
 class DataOutputStream : public v8::OutputStream {
  public:
-  using h_cb = void (*)(std::string, Data*);
+  typedef std::function<void(std::string, uint64_t*)> h_cb;
 
   DataOutputStream(h_cb cb,
                    const V8Object* object,

--- a/test/addons/nsolid-dispatchqueue/binding.gyp
+++ b/test/addons/nsolid-dispatchqueue/binding.gyp
@@ -5,6 +5,9 @@
       'sources': [ 'binding.cc' ],
       'includes': ['../common.gypi'],
       'defines': [ 'NODE_WANT_INTERNALS=1' ],
+      'include_dirs': [
+        '../../../deps/nsuv/include',
+      ],
     }
   ]
 }

--- a/test/addons/nsolid-eventloop-cmd/binding.gyp
+++ b/test/addons/nsolid-eventloop-cmd/binding.gyp
@@ -5,6 +5,9 @@
       'sources': [ 'binding.cc' ],
       'includes': ['../common.gypi'],
       'defines': [ 'NODE_WANT_INTERNALS=1' ],
+      'include_dirs': [
+        '../../../deps/nsuv/include',
+      ],
     }
   ]
 }


### PR DESCRIPTION
```
src: trim nsolid_heap_snapshot headers
```
```
src: move NSolidHeapSnapshot into EnvList
    
It doesn't need to be a Singleton anymore though theoretically still is.
Also, give more flexibility to the kind of functions that
`DataOutputStream` so it accepts lambdas with captured variables.
```