### PR TITLE
nsolid: support Heap Sampling

### DIFF
--- a/src/nsolid.cc
+++ b/src/nsolid.cc
@@ -521,14 +521,46 @@ int CpuProfiler::get_cpu_profile_(SharedEnvInst envinst,
                                                    deleter);
 }
 
+int Snapshot::start_allocation_sampling_(SharedEnvInst envinst,
+                                         uint64_t sample_interval,
+                                         int stack_depth,
+                                         v8::HeapProfiler::SamplingFlags flags,
+                                         uint64_t duration,
+                                         internal::user_data data,
+                                         snapshot_proxy_sig proxy) {
+  return EnvList::Inst()->HeapSnapshot()->StartSamplingProfiler(
+      envinst,
+      sample_interval,
+      stack_depth,
+      flags,
+      duration,
+      std::move(data),
+      proxy);
+}
+
+int Snapshot::StopSampling(SharedEnvInst envinst) {
+  if (envinst == nullptr)
+    return UV_ESRCH;
+
+  return EnvList::Inst()->HeapSnapshot()->StopSamplingProfiler(envinst);
+}
+
+int Snapshot::StopSamplingSync(SharedEnvInst envinst) {
+  if (envinst == nullptr)
+    return UV_ESRCH;
+
+  return EnvList::Inst()->HeapSnapshot()->StopSamplingProfilerSync(envinst);
+}
+
+
 int Snapshot::start_tracking_heap_objects_(SharedEnvInst envinst,
                                            bool redacted,
-                                           bool trackAllocations,
+                                           bool track_allocations,
                                            uint64_t duration,
                                            internal::user_data data,
                                            snapshot_proxy_sig proxy) {
   return EnvList::Inst()->HeapSnapshot()->StartTrackingHeapObjects(
-      envinst, redacted, trackAllocations, duration, std::move(data), proxy);
+      envinst, redacted, track_allocations, duration, std::move(data), proxy);
 }
 
 int Snapshot::StopTrackingHeapObjects(SharedEnvInst envinst) {

--- a/src/nsolid/nsolid_heap_snapshot.cc
+++ b/src/nsolid/nsolid_heap_snapshot.cc
@@ -8,11 +8,203 @@ namespace nsolid {
 
 NSolidHeapSnapshot::NSolidHeapSnapshot() {
   ASSERT_EQ(0, in_progress_heap_snapshots_.init(true));
+  ASSERT_EQ(0, in_progress_heap_sampling_.init(true));
+}
+
+int NSolidHeapSnapshot::StartSamplingProfiler(
+    SharedEnvInst envinst,
+    uint64_t sample_interval,
+    int stack_depth,
+    v8::HeapProfiler::SamplingFlags samplingFlag,
+    uint64_t duration,
+    internal::user_data data,
+    Snapshot::snapshot_proxy_sig proxy) {
+  uint64_t thread_id = envinst->thread_id();
+  uint64_t snaphot_id =
+    in_progress_timers_.fetch_add(1, std::memory_order_relaxed);
+
+  nsuv::ns_mutex::scoped_lock lock(&in_progress_heap_sampling_);
+  auto it = threads_running_heap_sampling_.emplace(
+      thread_id,
+      HeapSamplerStor{sample_interval,
+                      stack_depth,
+                      samplingFlag,
+                      duration,
+                      kFlagIsSamplingHeap,
+                      snaphot_id,
+                      proxy,
+                      std::move(data)});
+
+  if (it.second == false) {
+    return UV_EEXIST;
+  }
+
+  int status = RunCommand(envinst,
+                          CommandType::Interrupt,
+                          start_sampling_profiler,
+                          duration,
+                          snaphot_id,
+                          this);
+
+  if (status != 0) {
+    threads_running_heap_sampling_.erase(it.first);
+  }
+
+  return status;
+}
+
+int NSolidHeapSnapshot::StopSamplingProfiler(SharedEnvInst envinst) {
+  uint64_t thread_id = envinst->thread_id();
+  nsuv::ns_mutex::scoped_lock lock(&in_progress_heap_sampling_);
+  auto it = threads_running_heap_sampling_.find(thread_id);
+  // Make sure there is a snapshot running
+  if (it == threads_running_heap_sampling_.end() ||
+      !(it->second.flags & kFlagIsSamplingHeap)) {
+    return UV_ENOENT;
+  }
+
+  HeapSamplerStor& stor = it->second;
+  int er = RunCommand(envinst,
+                      CommandType::Interrupt,
+                      stop_sampling_profiler,
+                      stor.snapshot_id,
+                      this);
+  return er;
+}
+
+namespace {
+nlohmann::ordered_json build_sampling_heap_profile_node(
+    v8::Isolate* isolate, const v8::AllocationProfile::Node* node) {
+  nlohmann::ordered_json result;
+
+  // Construct callFrame
+  json callFrame = {
+    {"functionName", *v8::String::Utf8Value(isolate, node->name)},
+    {"scriptId", node->script_id},
+    {"url", *v8::String::Utf8Value(isolate, node->script_name)},
+    {"lineNumber", node->line_number - 1},
+    {"columnNumber", node->column_number - 1}
+  };
+
+  // Calculate selfSize
+  size_t selfSize = 0;
+  for (const auto& allocation : node->allocations)
+    selfSize += allocation.size * allocation.count;
+
+  // Add properties to result
+  result["callFrame"] = callFrame;
+  result["selfSize"] = selfSize;
+  result["id"] = node->node_id;
+
+  // Add children if there are any
+  if (node->children.empty())
+    return result;
+
+  // Recursively build children
+  nlohmann::ordered_json children;
+  for (const auto* child : node->children)
+    children.push_back(build_sampling_heap_profile_node(isolate, child));
+  result["children"] = children;
+
+  return result;
+}
+
+nlohmann::ordered_json build_v8_allocation_profile(
+    v8::Isolate* isolate,
+    v8::AllocationProfile* profile) {
+  // We need to parse the profile and convert it to a JSON string with the next
+  // schema, this does not support Serializing the profile to a string.
+  // { head: SamplingHeapProfileNode, samples: [SamplingHeapProfileSample] }
+  nlohmann::ordered_json json_profile;
+
+  v8::AllocationProfile::Node* root = profile->GetRootNode();
+  nlohmann::ordered_json head = build_sampling_heap_profile_node(isolate, root);
+  json_profile["head"] = head;
+
+  const std::vector<v8::AllocationProfile::Sample>& samples =
+    profile->GetSamples();
+
+  if (samples.empty()) {
+    json_profile["samples"] = nlohmann::ordered_json::array();
+    return json_profile;
+  }
+
+  for (const auto& sample : samples) {
+    nlohmann::ordered_json sample_json;
+    sample_json["size"] = sample.size * sample.count;
+    sample_json["nodeId"] = sample.node_id;
+    sample_json["ordinal"] = sample.sample_id;
+    json_profile["samples"].push_back(sample_json);
+  }
+
+  return json_profile;
+}
+}  // namespace
+
+int NSolidHeapSnapshot::StopSamplingProfilerSync(SharedEnvInst envinst) {
+  uint64_t thread_id = envinst->thread_id();
+  nsuv::ns_mutex::scoped_lock lock(&in_progress_heap_sampling_);
+  auto it = threads_running_heap_sampling_.find(thread_id);
+  // Make sure there is a snapshot running
+  if (it == threads_running_heap_sampling_.end())
+    return UV_ENOENT;
+
+  HeapSamplerStor& stor = it->second;
+  // If this condition is reached. This was called by EnvList::RemoveEnv.
+  // It wants to stop any pending snapshot w/ tracking heap object.
+  if (!(stor.flags & kFlagIsSamplingHeap) || stor.flags & kFlagIsDone) {
+    // If no pending trackers, just do nothing
+    // There are not pending snapshots with trackers
+    return UV_ENOENT;
+  }
+
+  v8::Isolate* isolate = envinst->isolate();
+  v8::HeapProfiler* profiler = isolate->GetHeapProfiler();
+  ASSERT_NOT_NULL(profiler);
+
+  v8::HandleScope scope(isolate);
+
+  // Get the sampled heap profile
+  v8::AllocationProfile* sampled = profiler->GetAllocationProfile();
+
+  if (sampled == nullptr) {
+    QueueCallback(sampling_cb,
+                  thread_id,
+                  // TODO(juan) - this is not a heap snapshot failure
+                  heap_profiler::HEAP_SNAPSHOT_FAILURE,
+                  std::string(),
+                  this);
+  } else {
+    nlohmann::ordered_json profile_json =
+      build_v8_allocation_profile(isolate, sampled);
+
+    stor.cb(0, profile_json.dump(), stor.data.get());
+    // Send the empty string to signal the end of the profile
+    stor.cb(0, std::string(), stor.data.get());
+
+    // V8 uses new, so we need to delete it
+    // This will make ASAN happy
+    delete sampled;
+  }
+  // Stop the profiler no matter what
+  profiler->StopSamplingHeapProfiler();
+
+  // Set the flag to done
+  stor.flags |= kFlagIsDone;
+  // Delete the snapshot from the map
+  threads_running_heap_sampling_.erase(it);
+  return 0;
 }
 
 NSolidHeapSnapshot::~NSolidHeapSnapshot() {
-  nsuv::ns_mutex::scoped_lock lock(&in_progress_heap_snapshots_);
-  threads_running_snapshots_.clear();
+  {
+    nsuv::ns_mutex::scoped_lock lock(&in_progress_heap_snapshots_);
+    threads_running_snapshots_.clear();
+  }
+  {
+    nsuv::ns_mutex::scoped_lock lock2(&in_progress_heap_sampling_);
+    threads_running_heap_sampling_.clear();
+  }
 }
 
 int NSolidHeapSnapshot::StartTrackingHeapObjects(
@@ -348,6 +540,142 @@ void NSolidHeapSnapshot::snapshot_cb(uint64_t thread_id,
   if (snapshot.empty()) {
     snapshotter->threads_running_snapshots_.erase(it);
   }
+}
+
+void NSolidHeapSnapshot::sampling_cb(uint64_t thread_id,
+                                     int status,
+                                     const std::string snapshot,
+                                     NSolidHeapSnapshot* snapshotter) {
+  nsuv::ns_mutex::scoped_lock lock(&snapshotter->in_progress_heap_sampling_);
+  auto it = snapshotter->threads_running_heap_sampling_.find(thread_id);
+  ASSERT(it != snapshotter->threads_running_heap_sampling_.end());
+  HeapSamplerStor& stor = it->second;
+  stor.cb(status, snapshot, stor.data.get());
+  if (snapshot.empty()) {
+    snapshotter->threads_running_heap_sampling_.erase(it);
+  }
+}
+
+void NSolidHeapSnapshot::start_sampling_profiler(
+    SharedEnvInst envinst,
+    uint64_t duration,
+    uint64_t snapshot_id,
+    NSolidHeapSnapshot* snapshotter) {
+  uint64_t thread_id = envinst->thread_id();
+  nsuv::ns_mutex::scoped_lock lock(&snapshotter->in_progress_heap_sampling_);
+  auto it = snapshotter->threads_running_heap_sampling_.find(thread_id);
+  ASSERT(it != snapshotter->threads_running_heap_sampling_.end());
+
+  HeapSamplerStor& stor = it->second;
+  ASSERT(stor.flags & kFlagIsSamplingHeap);
+
+  v8::Isolate* isolate = envinst->isolate();
+  v8::HeapProfiler* profiler = isolate->GetHeapProfiler();
+  ASSERT_NOT_NULL(profiler);
+
+  profiler->StartSamplingHeapProfiler(
+      stor.sample_interval,
+      stor.stack_depth,
+      stor.sampling_flags);
+
+  // Schedule a timer to take the snapshot
+  int er = QueueCallback(duration,
+                         stop_sampling_profiler,
+                         envinst,
+                         snapshot_id,
+                         snapshotter);
+
+  if (er) {
+    // In case the the thread is already gone, the cpu profile will be stopped
+    // on RemoveEnv, so do nothing here.
+  }
+}
+
+void NSolidHeapSnapshot::stop_sampling_profiler(
+    SharedEnvInst envinst,
+    uint64_t snapshot_id,
+    NSolidHeapSnapshot* snapshotter) {
+  uint64_t thread_id = envinst->thread_id();
+  nsuv::ns_mutex::scoped_lock lock(&snapshotter->in_progress_heap_sampling_);
+  auto it = snapshotter->threads_running_heap_sampling_.find(thread_id);
+  if (it == snapshotter->threads_running_heap_sampling_.end()) {
+    // The profiler was stopped before the timer was triggered
+    return;
+  }
+
+  HeapSamplerStor& stor = it->second;
+  if (stor.snapshot_id != snapshot_id) {
+    // The snapshot was stopped before the timer was triggered
+    return;
+  }
+
+  ASSERT(stor.flags & kFlagIsSamplingHeap);
+
+  // Give control back to the V8 thread
+  int er = RunCommand(envinst,
+                      CommandType::Interrupt,
+                      take_sampled_snapshot,
+                      snapshotter);
+  if (er) {
+    // In case the the thread is already gone, the heap sampling will be stopped
+    // on RemoveEnv, so do nothing here.
+  }
+}
+
+void NSolidHeapSnapshot::take_sampled_snapshot(
+    SharedEnvInst envinst,
+    NSolidHeapSnapshot* snapshotter) {
+  v8::Isolate* isolate = envinst->isolate();
+  v8::HeapProfiler* profiler = isolate->GetHeapProfiler();
+  ASSERT_NOT_NULL(profiler);
+
+  v8::HandleScope scope(isolate);
+
+  uint64_t thread_id = envinst->thread_id();
+  nsuv::ns_mutex::scoped_lock lock(&snapshotter->in_progress_heap_sampling_);
+  auto it = snapshotter->threads_running_heap_sampling_.find(thread_id);
+  ASSERT(it != snapshotter->threads_running_heap_sampling_.end());
+
+  HeapSamplerStor& stor = it->second;
+  // If this condition is reached. This was called by EnvList::RemoveEnv.
+  // It wants to stop any pending snapshot w/ tracking heap object.
+  if (!(stor.flags & kFlagIsSamplingHeap) || stor.flags & kFlagIsDone) {
+    // If no pending trackers, just do nothing
+    // There are not peding snapshots with trackers
+    return;
+  }
+
+  // Get the sampled heap profile
+  v8::AllocationProfile* sampled = profiler->GetAllocationProfile();
+  if (sampled == nullptr) {
+    QueueCallback(sampling_cb,
+                  thread_id,
+                  // TODO(juan) - this is not a heap snapshot failure
+                  heap_profiler::HEAP_SNAPSHOT_FAILURE,
+                  std::string(),
+                  snapshotter);
+  } else {
+    nlohmann::ordered_json profile_json =
+      build_v8_allocation_profile(isolate, sampled);
+
+    QueueCallback(sampling_cb,
+                  thread_id,
+                  0,
+                  profile_json.dump(),
+                  snapshotter);
+    QueueCallback(sampling_cb,
+                  thread_id,
+                  0,
+                  std::string(),
+                  snapshotter);
+
+    // V8 uses new, so we need to delete it
+    // This will make ASAN happy
+    delete sampled;
+  }
+  // Stop the profiler no matter what
+  profiler->StopSamplingHeapProfiler();
+  stor.flags |= kFlagIsDone;
 }
 
 }  // namespace nsolid

--- a/test/addons/nsolid-custom-command/binding.cc
+++ b/test/addons/nsolid-custom-command/binding.cc
@@ -66,11 +66,11 @@ static void custom_command_cb(std::string req_id,
                                   NewStringType::kNormal).ToLocalChecked();
   }
 
-  fn->Call(context,
+  v8::MaybeLocal<Value> ret = fn->Call(context,
            Undefined(isolate),
            5,
            argv);
-
+  assert(!ret.IsEmpty());
   cb_map_.erase(iter);
 }
 

--- a/test/addons/nsolid-heap-sampler/binding.gyp
+++ b/test/addons/nsolid-heap-sampler/binding.gyp
@@ -1,0 +1,16 @@
+{
+  'targets': [{
+    'target_name': 'binding',
+    'sources': [ 'binding.cc' ],
+    'includes': ['../common.gypi'],
+    'target_defaults': {
+      'default_configuration': 'Release',
+      'configurations': {
+        'Debug': {
+          'defines': [ 'DEBUG', '_DEBUG' ],
+          'cflags': [ '-g', '-O0', '-fstandalone-debug' ],
+        }
+      },
+    },
+  }],
+}

--- a/test/addons/nsolid-heap-sampler/nsolid-heap-sampler.js
+++ b/test/addons/nsolid-heap-sampler/nsolid-heap-sampler.js
@@ -1,0 +1,91 @@
+'use strict';
+// Flags: --expose-internals
+
+const { buildType, mustCall, skip } = require('../../common');
+const assert = require('assert');
+const bindingPath = require.resolve(`./build/${buildType}/binding`);
+const binding = require(bindingPath);
+const { Worker, isMainThread, parentPort, threadId } = require('worker_threads');
+const { internalBinding } = require('internal/test/binding');
+const { UV_EEXIST, UV_ENOENT } = internalBinding('uv');
+
+let er;
+
+if (process.env.NSOLID_COMMAND)
+  skip('required to run without the Console');
+
+if (!isMainThread && +process.argv[2] !== process.pid)
+  skip('Test must first run as the main thread');
+
+if (!isMainThread) {
+  // Starting the profile from this thread.
+  er = binding.startSampling(threadId, 5000);
+  assert.strictEqual(er, 0);
+  parentPort.postMessage('hi');
+  setTimeout(() => {}, 2000);
+  return;
+}
+
+const keepAlive = setInterval(() => {}, 1000);
+
+process.on('beforeExit', mustCall(() => {
+  er = binding.stopSampling(0);
+  // It could be peding or not.
+  assert.ok(er === 0 || er === UV_ENOENT);
+}));
+
+// Normal usage check.
+er = binding.startSampling(threadId, 10000, mustCall((status, profile) => {
+  assert.strictEqual(status, 0);
+  assert(JSON.parse(profile));
+
+  // // Check error codes for invalid calls.
+  er = binding.startSampling(threadId, 10000, mustCall((status, profile) => {
+    assert.strictEqual(status, 0);
+    assert(JSON.parse(profile));
+
+    er = binding.stopSampling(threadId);
+    assert.strictEqual(er, UV_ENOENT);
+    // Test getting profile
+    er = binding.startSampling(threadId, 10, mustCall((status, profile) => {
+      assert.strictEqual(status, 0);
+      assert(JSON.parse(profile));
+
+      er = binding.stopSampling(threadId);
+      assert.strictEqual(er, UV_ENOENT);
+      testWorker();
+      clearInterval(keepAlive);
+    }));
+    assert.strictEqual(er, 0);
+  }));
+
+  assert.strictEqual(er, 0);
+  er = binding.startSampling(threadId, 10);
+  assert.strictEqual(er, UV_EEXIST);
+  er = binding.stopSamplingSync(threadId);
+  assert.strictEqual(er, 0);
+}));
+
+assert.strictEqual(er, 0);
+er = binding.stopSampling(threadId);
+assert.strictEqual(er, 0);
+
+function testWorker() {
+  const worker = new Worker(__filename, { argv: [process.pid] });
+  worker.on('exit', mustCall((code) => {
+    assert.strictEqual(code, 0);
+  }));
+  worker.once('message', mustCall((msg) => {
+    assert.strictEqual(msg, 'hi');
+
+    er = binding.startSampling(worker.threadId, 500);
+    assert.strictEqual(er, UV_EEXIST);
+
+    er = binding.stopSampling(worker.threadId);
+    assert.strictEqual(er, 0);
+    setTimeout(() => {
+      er = binding.startSampling(threadId, 2000);
+      assert.strictEqual(er, 0);
+    }, 2000);
+  }));
+}


### PR DESCRIPTION
This patch adds support to the "sampled" heapsnapshot.

This new API methods in N|Solid allow users to sample allocations in the V8 heap; internally it does the calls to the V8 Profiler for start sampling and stop sampling.

This patch requires a new mutex and a new thread map to manage which thread is currently sampling, same as CPU profiler and HeapSnapshot.

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
