### PR TITLE
agents: fix agent reconnect handshake on ZmqAgent

### DIFF
--- a/agents/zmq/src/zmq_agent.cc
+++ b/agents/zmq/src/zmq_agent.cc
@@ -1012,13 +1012,7 @@ int ZmqAgent::setup_metrics_timer(uint64_t period) {
   return metrics_timer_.start(metrics_timer_cb, 0, period, this);
 }
 
-// Implement negotiation process for data and bulk endpoints.
-// For the moment, only if those endpoints have not already been configured
 int ZmqAgent::config_sockets(const json& sockets) {
-  if (data_handle_ && bulk_handle_) {
-    return 0;
-  }
-
   std::unique_ptr<ZmqEndpoint> command_endpt;
   std::unique_ptr<ZmqEndpoint> data_endpt;
   std::unique_ptr<ZmqEndpoint> bulk_endpt;
@@ -1030,20 +1024,16 @@ int ZmqAgent::config_sockets(const json& sockets) {
                           ZmqHandle::get_default_port(ZmqHandle::Command)));
   }
 
-  if (!data_handle_) {
-    it = sockets.find("dataBindAddr");
-    if (it != sockets.end()) {
-      data_endpt.reset(
-        ZmqEndpoint::create(*it, ZmqHandle::get_default_port(ZmqHandle::Data)));
-    }
+  it = sockets.find("dataBindAddr");
+  if (it != sockets.end()) {
+    data_endpt.reset(
+      ZmqEndpoint::create(*it, ZmqHandle::get_default_port(ZmqHandle::Data)));
   }
 
-  if (!bulk_handle_) {
-    it = sockets.find("bulkBindAddr");
-    if (it != sockets.end()) {
-      bulk_endpt.reset(
-        ZmqEndpoint::create(*it, ZmqHandle::get_default_port(ZmqHandle::Bulk)));
-    }
+  it = sockets.find("bulkBindAddr");
+  if (it != sockets.end()) {
+    bulk_endpt.reset(
+      ZmqEndpoint::create(*it, ZmqHandle::get_default_port(ZmqHandle::Bulk)));
   }
 
   if (!data_endpt && !bulk_endpt) {

--- a/test/agents/test-zmq-handshake.mjs
+++ b/test/agents/test-zmq-handshake.mjs
@@ -1,0 +1,67 @@
+import { mustSucceed } from '../common/index.mjs';
+import assert from 'node:assert';
+import {
+  checkExitData,
+  TestPlayground,
+} from '../common/nsolid-zmq-agent/index.js';
+
+const tests = [];
+
+tests.push({
+  name: 'should work if agent exits gracefully without error',
+  test: async (saas, playground) => {
+    return new Promise((resolve) => {
+      const state = {
+        id: null,
+        events: saas ? -1 : 0,
+        authCount: 0,
+      };
+
+      playground.bootstrap(mustSucceed(async (agentId) => {
+        await playground.stopServer();
+        playground.updateConfig({
+          dataBindAddr: 'tcp://*:9004',
+          bulkBindAddr: 'tcp://*:9005'
+        });
+
+        await playground.startServer();
+      }), (eventType, agentId, data) => {
+        playground.detectInitialSequence(state, eventType, data, agentId, async (err) => {
+          assert.ifError(err);
+          const exit = await playground.client.shutdown(0);
+          assert.ok(exit);
+          assert.strictEqual(exit.code, 0);
+          assert.strictEqual(exit.signal, null);
+          resolve();
+        }, (eventType, agentId, data) => {
+          assert.strictEqual(eventType, 'agent-exit');
+          checkExitData(data, { exit_code: 0, error: null });
+        });
+      });
+    });
+  },
+});
+
+const config = {
+  commandBindAddr: 'tcp://*:9001',
+  dataBindAddr: 'tcp://*:9002',
+  bulkBindAddr: 'tcp://*:9003',
+  HWM: 0,
+  bulkHWM: 0,
+  commandTimeoutMilliseconds: 5000,
+};
+
+for (const saas of [false, true]) {
+  config.saas = saas;
+  const label = saas ? 'saas' : 'local';
+  const playground = new TestPlayground(config);
+  await playground.startServer();
+
+  for (const { name, test } of tests) {
+    console.log(`[${label}] zmq handshake ${name}`);
+    await test(saas, playground);
+    await playground.stopClient();
+  }
+
+  await playground.stopServer();
+}

--- a/test/common/nsolid-zmq-agent/zmqagentbus.js
+++ b/test/common/nsolid-zmq-agent/zmqagentbus.js
@@ -215,6 +215,11 @@ class ZmqAgentBus extends EventEmitter {
     this.server.shutdown(cb);
   }
 
+  updateConfig(config) {
+    this.serverConfig = { ...this.serverConfig, ...config };
+    this.server.config = this.serverConfig;
+  }
+
   // ****************
   // Translate the AgentBus interface into ZeroMQ messages
   //


### PR DESCRIPTION
In the event that the server changes the `dataBindAddr` and/or `bulkBindAddr`, the agent should be able to reconnect those channels to the new locations.
A bit of refactoring of the test helper classes to allow a ZmqServer to change its configuration.

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
