### PR TITLE
lib: add nsolid JS API for heap sampling

### DIFF
--- a/agents/zmq/src/zmq_agent.cc
+++ b/agents/zmq/src/zmq_agent.cc
@@ -2366,6 +2366,13 @@ int ZmqAgent::stop_heap_profiling(uint64_t thread_id) {
   return Snapshot::StopTrackingHeapObjectsSync(GetEnvInst(thread_id));
 }
 
+int ZmqAgent::stop_heap_sampling(uint64_t thread_id) {
+  // This method is only called from the JS thread the profile it's stopping is
+  // running so the sync StopSamplingSync method can be safely
+  // called.
+  return Snapshot::StopSamplingSync(GetEnvInst(thread_id));
+}
+
 void ZmqAgent::status_command_cb(SharedEnvInst, ZmqAgent* agent) {
   agent->status_cb_(agent->status());
 }

--- a/doc/api/errors.md
+++ b/doc/api/errors.md
@@ -3661,6 +3661,18 @@ Error when trying to start taking a heap profile with the JS API.
 
 Error when trying to stop a heap profile being taken with the JS API.
 
+<a id="ERR_NSOLID_HEAP_SAMPLING_START"></a>
+
+### `ERR_NSOLID_HEAP_SAMPLING_START`
+
+Error when trying to start taking a heap sampling with the JS API.
+
+<a id="ERR_NSOLID_HEAP_SAMPLING_STOP"></a>
+
+### `ERR_NSOLID_HEAP_SAMPLING_STOP`
+
+Error when trying to stop a heap sampling being taken with the JS API.
+
 <a id="ERR_NSOLID_HEAP_SNAPSHOT"></a>
 
 ### `ERR_NSOLID_HEAP_SNAPSHOT`

--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -1658,6 +1658,10 @@ E('ERR_NSOLID_HEAP_PROFILE_START',
   'Heap profile could not be started', Error);
 E('ERR_NSOLID_HEAP_PROFILE_STOP',
   'Heap profile could not be stopped', Error);
+E('ERR_NSOLID_HEAP_SAMPLING_START',
+  'Heap sampling could not be started', Error);
+E('ERR_NSOLID_HEAP_SAMPLING_STOP',
+  'Heap sampling could not be stopped', Error);
 E('ERR_NSOLID_HEAP_SNAPSHOT',
   'Heap snapshot could not be generated', Error);
 E('ERR_NSOLID_OTEL_API_ALREADY_REGISTERED',

--- a/lib/nsolid.js
+++ b/lib/nsolid.js
@@ -18,6 +18,7 @@ const { Readable } = require('stream');
 const {
   validateBoolean,
   validateNumber,
+  validateObject,
 } = require('internal/validators');
 
 const {
@@ -39,6 +40,7 @@ const zmq = require('internal/agents/zmq/lib/nsolid');
 const {
   codes: {
     ERR_NSOLID_HEAP_PROFILE_START,
+    ERR_NSOLID_HEAP_SAMPLING_START,
     ERR_INVALID_ARG_TYPE,
   },
 } = require('internal/errors');
@@ -124,6 +126,9 @@ ObjectAssign(start, {
   heapProfileStream,
   heapProfile: zmq.heapProfile,
   heapProfileEnd: zmq.heapProfileEnd,
+  heapSamplingStream,
+  heapSampling: zmq.heapSampling,
+  heapSamplingEnd: zmq.heapSamplingEnd,
   profile: zmq.profile,
   profileEnd: zmq.profileEnd,
   on,
@@ -388,6 +393,75 @@ function heapProfileStream(threadId, duration, trackAllocations) {
 
   if (ret !== 0) {
     const err = new ERR_NSOLID_HEAP_PROFILE_START();
+    err.code = ret;
+    readable.destroy(err);
+  }
+
+  return readable;
+}
+
+const defaultHeapSamplingOptions = { sampleInterval: 512 * 1024, stackDepth: 16, flags: 0 };
+
+/**
+ * Starts a heap sampling in a specific JS thread and returns a readable stream
+ * of the profile data.
+ * @param {number} threadId - The ID of the thread for which to start the heap sampling.
+ * @param {number} duration - The duration in milliseconds for which to run the heap sampling.
+ * @param {object} [options={ sampleInterval: 512 * 1024, stackDepth: 16, flags: 0 }]
+ * @param {number} options.sampleInterval every allocation will be allocated every `sampleInterval` bytes
+ * @param {string} options.stackDepth stack depth to capture
+ * @param {string} options.flags flags to pass to the profiler. See:
+ * https://v8docs.nodesource.com/node-20.3/d7/d76/classv8_1_1_heap_profiler.html#a785d454e7866f222e199d667be567392
+ * @example
+ * const nsolid = require('nsolid');
+ * const threadId = 1;
+ * const duration = 5000; // 5 seconds
+ * const trackAllocations = true;
+ * const heapSamplingStream = nsolid.heapSamplingStream(threadId, duration, {});
+ * heapSamplingStream.on('data', (data) => {
+ *   console.log('Heap Sampling Data:', data);
+ * });
+ * heapSamplingStream.on('error', (err) => {
+ *   console.error('Error:', err);
+ * });
+ * @returns {Readable} A readable stream of the heap sampling data. It emits an
+ * {ERR_NSOLID_HEAP_SAMPLING_START} If there is an error starting the heap profile.
+ * @alias module:nsolid.heapSamplingStream
+ */
+function heapSamplingStream(threadId, duration, options) {
+  validateNumber(threadId, 'threadId');
+  validateNumber(duration, 'duration');
+  options = options || {};
+  validateObject(options, 'options');
+  options = { ...defaultHeapSamplingOptions, ...options };
+  validateNumber(options.sampleInterval, 'options.sampleInterval');
+  validateNumber(options.stackDepth, 'options.stackDepth');
+  validateNumber(options.flags, 'options.flags');
+  const readable = new Readable({
+    read() {
+    },
+    destroy(err, cb) {
+      binding.heapSamplingEnd(threadId);
+      if (typeof cb === 'function')
+        cb(err);
+    },
+  });
+
+  const { sampleInterval, stackDepth, flags } = options;
+  const ret = binding.heapSampling(threadId, duration, sampleInterval, stackDepth, flags, (status, data) => {
+    if (status !== 0) {
+      const err = new ERR_NSOLID_HEAP_SAMPLING_START();
+      err.code = status;
+      readable.destroy(err);
+    } else if (data === null) {
+      readable.push(null);
+    } else {
+      readable.push(data);
+    }
+  });
+
+  if (ret !== 0) {
+    const err = new ERR_NSOLID_HEAP_SAMPLING_START();
     err.code = ret;
     readable.destroy(err);
   }

--- a/src/nsolid/nsolid_api.cc
+++ b/src/nsolid/nsolid_api.cc
@@ -2579,6 +2579,56 @@ static void HeapProfileEnd(const FunctionCallbackInfo<Value>& args) {
 }
 
 
+static void HeapSampling(const FunctionCallbackInfo<Value>& args) {
+  CHECK(args[0]->IsNumber());  // thread_id
+  CHECK(args[1]->IsNumber());  // duration
+  CHECK(args[2]->IsNumber());  // sample_interval
+  CHECK(args[3]->IsUint32());  // stack_depth
+  CHECK(args[4]->IsUint32());  // flags
+  CHECK(args[5]->IsFunction());  // stream cb
+  uint64_t thread_id = args[0].As<Number>()->Value();
+  uint64_t duration = args[1].As<Number>()->Value();
+  uint64_t sample_interval = args[2].As<Number>()->Value();
+  int stack_depth = args[3].As<Uint32>()->Value();
+  v8::HeapProfiler::SamplingFlags flags =
+    static_cast<v8::HeapProfiler::SamplingFlags>(args[4].As<Uint32>()->Value());
+  SharedEnvInst envinst = EnvInst::GetInst(thread_id);
+  Isolate* isolate = args.GetIsolate();
+  v8::Global<Function> cb(isolate, args[5].As<Function>());
+  std::shared_ptr<v8::Global<Function>> cb_ptr(
+    new v8::Global<Function>(std::move(cb)),
+    [](v8::Global<Function>* ptr) {
+      ptr->Reset();
+      delete ptr;
+    });
+
+  SharedEnvInst current_envinst = EnvInst::GetCurrent(isolate);
+  int ret = Snapshot::StartSampling(envinst,
+                                    sample_interval,
+                                    stack_depth,
+                                    flags,
+                                    duration,
+                                    heapprofile_cb,
+                                    current_envinst,
+                                    std::move(cb_ptr));
+  if (ret == 0) {
+    // Add a reference to the current environment to prevent the loop from
+    // exiting.
+    current_envinst->env()->add_refs(1);
+  }
+
+  args.GetReturnValue().Set(ret);
+}
+
+static void HeapSamplingEnd(const FunctionCallbackInfo<Value>& args) {
+  CHECK(args[0]->IsNumber());  // thread_id
+  uint64_t thread_id = args[0].As<Number>()->Value();
+  SharedEnvInst envinst = EnvInst::GetInst(thread_id);
+  int ret = Snapshot::StopSampling(envinst);
+  args.GetReturnValue().Set(ret);
+}
+
+
 static void CustomCommandResponse(const FunctionCallbackInfo<Value>& args) {
   CHECK(args[0]->IsString());
   CHECK(args[1]->IsString());
@@ -2784,6 +2834,8 @@ void BindingData::Initialize(Local<Object> target,
   SetMethod(context, target, "getTraceId", GetTraceId);
   SetMethod(context, target, "heapProfile", HeapProfile);
   SetMethod(context, target, "heapProfileEnd", HeapProfileEnd);
+  SetMethod(context, target, "heapSampling", HeapSampling);
+  SetMethod(context, target, "heapSamplingEnd", HeapSamplingEnd);
 
   SetMethod(context, target, "_getOnBlockedBody", GetOnBlockedBody);
   SetMethod(context, target, "_setupArrayBuffers", SetupArrayBuffers);
@@ -2911,6 +2963,8 @@ void BindingData::RegisterExternalReferences(
   registry->Register(GetTraceId);
   registry->Register(HeapProfile);
   registry->Register(HeapProfileEnd);
+  registry->Register(HeapSampling);
+  registry->Register(HeapSamplingEnd);
   registry->Register(GetOnBlockedBody);
   registry->Register(SetupArrayBuffers);
 }

--- a/test/parallel/test-nsolid-heap-sampling-stream.js
+++ b/test/parallel/test-nsolid-heap-sampling-stream.js
@@ -1,0 +1,111 @@
+// Flags: --expose-internals
+'use strict';
+
+const common = require('../common');
+const assert = require('assert');
+const nsolid = require('nsolid');
+const { internalBinding } = require('internal/test/binding');
+
+const {
+  UV_ESRCH,
+} = internalBinding('uv');
+
+[ true, 'foo', /a/, Symbol()].forEach((arg) => {
+  assert.throws(
+    () => {
+      nsolid.heapSamplingStream(arg);
+    },
+    {
+      message: 'The "threadId" argument must be of type number.' +
+               common.invalidArgTypeHelper(arg),
+      code: 'ERR_INVALID_ARG_TYPE'
+    }
+  );
+});
+
+[ true, 'foo', /a/, Symbol()].forEach((arg) => {
+  assert.throws(
+    () => {
+      nsolid.heapSamplingStream(0, arg);
+    },
+    {
+      message: 'The "duration" argument must be of type number.' +
+               common.invalidArgTypeHelper(arg),
+      code: 'ERR_INVALID_ARG_TYPE'
+    }
+  );
+});
+
+[ 'foo', 5, true, Symbol()].forEach((arg) => {
+  assert.throws(
+    () => {
+      nsolid.heapSamplingStream(0, 5, arg);
+    },
+    {
+      message: 'The "options" argument must be of type object.' +
+               common.invalidArgTypeHelper(arg),
+      code: 'ERR_INVALID_ARG_TYPE'
+    }
+  );
+});
+
+[ true, 'foo', /a/, Symbol()].forEach((arg) => {
+  assert.throws(
+    () => {
+      const opts = { sampleInterval: arg };
+      nsolid.heapSamplingStream(0, 5, opts);
+    },
+    {
+      message: 'The "options.sampleInterval" property must be of type number.' +
+               common.invalidArgTypeHelper(arg),
+      code: 'ERR_INVALID_ARG_TYPE'
+    }
+  );
+});
+
+[ true, 'foo', /a/, Symbol()].forEach((arg) => {
+  assert.throws(
+    () => {
+      const opts = { stackDepth: arg };
+      nsolid.heapSamplingStream(0, 5, opts);
+    },
+    {
+      message: 'The "options.stackDepth" property must be of type number.' +
+               common.invalidArgTypeHelper(arg),
+      code: 'ERR_INVALID_ARG_TYPE'
+    }
+  );
+});
+
+[ true, 'foo', /a/, Symbol()].forEach((arg) => {
+  assert.throws(
+    () => {
+      const opts = { flags: arg };
+      nsolid.heapSamplingStream(0, 5, opts);
+    },
+    {
+      message: 'The "options.flags" property must be of type number.' +
+               common.invalidArgTypeHelper(arg),
+      code: 'ERR_INVALID_ARG_TYPE'
+    }
+  );
+});
+
+{
+  const stream = nsolid.heapSamplingStream(10, 12000);
+  stream.on('error', common.mustCall((err) => {
+    assert.strictEqual(err.message, 'Heap sampling could not be started');
+    assert.strictEqual(err.code, UV_ESRCH);
+  }));
+}
+
+{
+  let profile = '';
+  const stream = nsolid.heapSamplingStream(0, 1200);
+  stream.on('data', (data) => {
+    profile += data;
+  });
+  stream.on('end', common.mustCall(() => {
+    assert(JSON.parse(profile));
+  }));
+}

--- a/test/parallel/test-nsolid-heap-sampling.js
+++ b/test/parallel/test-nsolid-heap-sampling.js
@@ -1,0 +1,172 @@
+'use strict';
+
+const common = require('../common');
+const assert = require('assert');
+const nsolid = require('nsolid');
+
+[ true, 'foo', /a/, Symbol()].forEach((arg) => {
+  assert.throws(
+    () => {
+      nsolid.heapSampling(arg);
+    },
+    {
+      message: 'The "duration" argument must be of type number.' +
+               common.invalidArgTypeHelper(arg),
+      code: 'ERR_INVALID_ARG_TYPE'
+    }
+  );
+});
+
+[ 'foo', 5, true, Symbol()].forEach((arg) => {
+  assert.throws(
+    () => {
+      nsolid.heapSampling(5, arg);
+    },
+    {
+      message: 'The "options" argument must be of type object.' +
+               common.invalidArgTypeHelper(arg),
+      code: 'ERR_INVALID_ARG_TYPE'
+    }
+  );
+});
+
+[ true, 'foo', /a/, Symbol()].forEach((arg) => {
+  assert.throws(
+    () => {
+      const opts = { sampleInterval: arg };
+      nsolid.heapSampling(5, opts);
+    },
+    {
+      message: 'The "options.sampleInterval" property must be of type number.' +
+               common.invalidArgTypeHelper(arg),
+      code: 'ERR_INVALID_ARG_TYPE'
+    }
+  );
+});
+
+[ true, 'foo', /a/, Symbol()].forEach((arg) => {
+  assert.throws(
+    () => {
+      const opts = { stackDepth: arg };
+      nsolid.heapSampling(5, opts);
+    },
+    {
+      message: 'The "options.stackDepth" property must be of type number.' +
+               common.invalidArgTypeHelper(arg),
+      code: 'ERR_INVALID_ARG_TYPE'
+    }
+  );
+});
+
+[ true, 'foo', /a/, Symbol()].forEach((arg) => {
+  assert.throws(
+    () => {
+      const opts = { flags: arg };
+      nsolid.heapSampling(5, opts);
+    },
+    {
+      message: 'The "options.flags" property must be of type number.' +
+               common.invalidArgTypeHelper(arg),
+      code: 'ERR_INVALID_ARG_TYPE'
+    }
+  );
+});
+
+[ null, false, true, 'foo', 5, /a/, Symbol()].forEach((arg) => {
+  assert.throws(
+    () => {
+      nsolid.heapSampling(5, {}, arg);
+    },
+    {
+      message: 'The "heapSamplingCallback" argument must be of type function.' +
+               common.invalidArgTypeHelper(arg),
+      code: 'ERR_INVALID_ARG_TYPE'
+    }
+  );
+});
+
+[ null, false, true, 'foo', 5, /a/, Symbol()].forEach((arg) => {
+  assert.throws(
+    () => {
+      nsolid.heapSamplingEnd(arg);
+    },
+    {
+      message: 'The "heapSamplingEndCallback" argument must be of type function.' +
+               common.invalidArgTypeHelper(arg),
+      code: 'ERR_INVALID_ARG_TYPE'
+    }
+  );
+});
+
+// profile() should return error if not connected to a console
+assert.throws(
+  () => {
+    nsolid.heapSampling();
+  },
+  {
+    message: 'Heap sampling could not be started'
+  }
+);
+
+nsolid.heapSampling(common.mustCall((err) => {
+  assert.notStrictEqual(err.code, 0);
+  assert.strictEqual(err.message, 'Heap sampling could not be started');
+}));
+
+// Configure the console so the `profile()` call may succeed
+nsolid.start({
+  command: 'localhost:9001',
+  data: 'localhost:9002'
+});
+
+setTimeout(() => {
+  // profile() should return an error if ongoing profile
+  assert.strictEqual(nsolid.heapSampling(), undefined);
+  assert.throws(
+    () => {
+      nsolid.heapSampling();
+    },
+    {
+      message: 'Heap sampling could not be started'
+    }
+  );
+
+  nsolid.heapSampling(common.mustCall((err) => {
+    assert.notStrictEqual(err.code, 0);
+    assert.strictEqual(err.message, 'Heap sampling could not be started');
+  }));
+  assert.strictEqual(nsolid.heapSamplingEnd(), undefined);
+
+  setTimeout(() => {
+    // profileEnd() should return an error if no ongoing profile
+    assert.throws(
+      () => {
+        nsolid.heapSamplingEnd();
+      },
+      {
+        message: 'Heap sampling could not be stopped'
+      }
+    );
+
+    nsolid.heapSamplingEnd(common.mustCall((err) => {
+      assert.notStrictEqual(err.code, 0);
+      assert.strictEqual(err.message, 'Heap sampling could not be stopped');
+      // The same with callback versions
+      // profile() should return an error if ongoing profile
+      nsolid.heapSampling(common.mustSucceed(() => {
+        nsolid.heapSampling(common.mustCall((err) => {
+          assert.notStrictEqual(err.code, 0);
+          assert.strictEqual(err.message, 'Heap sampling could not be started');
+          nsolid.heapSamplingEnd(common.mustSucceed(() => {
+            // profileEnd() should return an error if no ongoing profile
+            nsolid.heapSamplingEnd(common.mustCall((err) => {
+              assert.notStrictEqual(err.code, 0);
+              assert.strictEqual(err.message,
+                                 'Heap sampling could not be stopped');
+            }));
+          }));
+        }));
+      }));
+    }));
+  }, 100);
+}, 100);


### PR DESCRIPTION
It involves two different set of API's.

The first one, is the classic `N|Solid` api which will create a profile and send it to the Console. It consists of the following methods:
- `heapSampling()` and `heapSamplingEnd()`.

The second allows to retrieve the heap profile via a `Readable` using the following method:

```
const stream = heapSamplingStream(threadId, duration, options);
```

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
