### PR TITLE
lib,src: remove EnvList Get/SetTimeOrigin methods

### DIFF
--- a/lib/internal/nsolid_loader.js
+++ b/lib/internal/nsolid_loader.js
@@ -1,8 +1,5 @@
 'use strict';
 
-const {
-  getTimeOriginTimestamp,
-} = require('internal/perf/utils');
 const binding = internalBinding('nsolid_api');
 // Simply require this here in order to initialize it.
 require('internal/agents/statsd/lib/nsolid');
@@ -33,8 +30,4 @@ function init() {
     delay = 0;
   }
   binding.runStartInTimeout(() => require('nsolid').start(), delay);
-
-  // Store the performance.timeOrigin value so we can use it to calculate the
-  // current timestamp with higher precision using performance.now().
-  binding.setTimeOrigin(getTimeOriginTimestamp());
 }

--- a/src/nsolid/nsolid_api.cc
+++ b/src/nsolid/nsolid_api.cc
@@ -2442,12 +2442,6 @@ static void setThreadName(const FunctionCallbackInfo<Value>& args) {
 }
 
 
-static void SetTimeOrigin(const FunctionCallbackInfo<Value>& args) {
-  CHECK(args[0]->IsNumber());
-  EnvList::Inst()->SetTimeOrigin(args[0].As<Number>()->Value());
-}
-
-
 static void SetToggleTracingFn(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);
   CHECK(args[0]->IsFunction());
@@ -2827,7 +2821,6 @@ void BindingData::Initialize(Local<Object> target,
             AttachRequestToCustomCommand);
   SetMethod(context, target, "getThreadName", getThreadName);
   SetMethod(context, target, "setThreadName", setThreadName);
-  SetMethod(context, target, "setTimeOrigin", SetTimeOrigin);
   SetMethod(context, target, "setToggleTracingFn", SetToggleTracingFn);
   SetMethod(context, target, "setTrackPromisesFn", SetTrackPromisesFn);
   SetMethod(context, target, "getSpanId", GetSpanId);
@@ -2956,7 +2949,6 @@ void BindingData::RegisterExternalReferences(
   registry->Register(AttachRequestToCustomCommand);
   registry->Register(getThreadName);
   registry->Register(setThreadName);
-  registry->Register(SetTimeOrigin);
   registry->Register(SetToggleTracingFn);
   registry->Register(SetTrackPromisesFn);
   registry->Register(GetSpanId);

--- a/src/nsolid/nsolid_api.h
+++ b/src/nsolid/nsolid_api.h
@@ -542,10 +542,6 @@ class EnvList {
 
   void UpdateTracingFlags(uint32_t flags);
 
-  void SetTimeOrigin(double t) { time_origin_ = t; }
-
-  double GetTimeOrigin() const { return time_origin_; }
-
   inline uv_thread_t thread();
   inline size_t env_map_size();
   inline nsuv::ns_mutex* command_lock();
@@ -680,8 +676,6 @@ class EnvList {
   TSQueue<std::string> trace_id_q_;
   tracing::TracerImpl tracer_;
   DispatchQueue<tracing::SpanItem> span_item_q_;
-
-  double time_origin_;
 
   NSolidHeapSnapshot heap_snapshot_;
 };

--- a/src/nsolid/nsolid_trace.cc
+++ b/src/nsolid/nsolid_trace.cc
@@ -41,10 +41,12 @@ Span::Span(uint64_t thread_id) {
 
 
 void Span::add_prop(const SpanPropBase& prop) {
+  static double performance_process_start_timestamp =
+    performance::performance_process_start_timestamp / 1e3;
   switch (prop.type()) {
     case Span::kSpanStart:
     {
-      stor_.start = EnvList::Inst()->GetTimeOrigin() + prop.val<double>();
+      stor_.start = performance_process_start_timestamp + prop.val<double>();
     }
     break;
     case Span::kSpanOtelIds:
@@ -61,7 +63,7 @@ void Span::add_prop(const SpanPropBase& prop) {
     break;
     case Span::kSpanEnd:
     {
-      stor_.end = EnvList::Inst()->GetTimeOrigin() + prop.val<double>();
+      stor_.end = performance_process_start_timestamp + prop.val<double>();
     }
     break;
     case Span::kSpanName:


### PR DESCRIPTION
There's no need to use them as the value can be accessed directly via `performance::performance_process_start_timestamp`.

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
