### PR TITLE
src: fix blocked_time calculation

### DIFF
--- a/src/nsolid/nsolid_api.cc
+++ b/src/nsolid/nsolid_api.cc
@@ -1493,7 +1493,6 @@ void EnvList::env_list_routine_(ns_thread*, EnvList* envlist) {
 
 void EnvList::blocked_loop_timer_cb_(ns_timer*) {
   EnvList* envlist = EnvList::Inst();
-  uint64_t now = uv_hrtime();
   // Adjust from milliseconds to nanoseconds.
   uint64_t min_threshold_ns = envlist->min_blocked_threshold_ * 1000000;
   std::list<SharedEnvInst> envinst_list;
@@ -1512,6 +1511,7 @@ void EnvList::blocked_loop_timer_cb_(ns_timer*) {
     // TODO(trevnorris): REMOVE provider_times so libuv don't need to use the
     // floating patch.
     uint64_t exit_time = envinst_sp->provider_times().second;
+    uint64_t now = uv_hrtime();
     uint64_t blocked_time = exit_time == 0 ? 0 : now - exit_time;
 
     if (blocked_time < min_threshold_ns || envinst_sp->reported_blocked_)


### PR DESCRIPTION
We should be retrieving `now` on every iteration so `blocked_time` is more accurate. On high cpu usage scenarios we were observing negative `blocked_time` which is obviously bogus and was causing false positives.

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
