### PR TITLE
agents: make tcp/udp inherit from virtual class

### DIFF
--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -9,6 +9,7 @@ on:
       - src/**/*.h
       - tools/gyp/**
       - .github/workflows/build-windows.yml
+      - agents/**
     types: [opened, synchronize, reopened, ready_for_review]
   push:
     branches:
@@ -23,6 +24,7 @@ on:
       - src/**/*.h
       - tools/gyp/**
       - .github/workflows/build-windows.yml
+      - agents/**
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}

--- a/.github/workflows/coverage-linux-without-intl.yml
+++ b/.github/workflows/coverage-linux-without-intl.yml
@@ -12,6 +12,7 @@ on:
       - tools/gyp/**
       - tools/test.py
       - .github/workflows/coverage-linux-without-intl.yml
+      - agents/**
   push:
     branches:
       - main
@@ -24,6 +25,7 @@ on:
       - tools/gyp/**
       - tools/test.py
       - .github/workflows/coverage-linux-without-intl.yml
+      - agents/**
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}

--- a/.github/workflows/coverage-linux.yml
+++ b/.github/workflows/coverage-linux.yml
@@ -12,6 +12,7 @@ on:
       - tools/gyp/**
       - tools/test.py
       - .github/workflows/coverage-linux.yml
+      - agents/**
   push:
     branches:
       - main
@@ -24,6 +25,7 @@ on:
       - tools/gyp/**
       - tools/test.py
       - .github/workflows/coverage-linux.yml
+      - agents/**
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}

--- a/.github/workflows/coverage-windows.yml
+++ b/.github/workflows/coverage-windows.yml
@@ -12,6 +12,7 @@ on:
       - tools/gyp/**
       - tools/test.py
       - .github/workflows/coverage-windows.yml
+      - agents/**
   push:
     branches:
       - main
@@ -24,6 +25,7 @@ on:
       - tools/gyp/**
       - tools/test.py
       - .github/workflows/coverage-windows.yml
+      - agents/**
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}

--- a/agents/statsd/src/statsd_agent.cc
+++ b/agents/statsd/src/statsd_agent.cc
@@ -108,6 +108,7 @@ int StatsDTcp::write(const string_vector& messages) {
     connect_();
   }
 
+  internal_state_ |= kWriting;
   req->set_data(sv);
   return r;
 }
@@ -180,9 +181,6 @@ void StatsDTcp::write_cb_(nsuv::ns_write<nsuv::ns_tcp>* req,
   delete sv;
   delete req;
 
-  // TODO(trevnorris): Valgrind had a failure here accessing tcp. It must have
-  // become invalid. So that means I need to be checking internal_state_
-  // somewhere instead of just deleting it.
   tcp->internal_state_ &= ~kWriting;
   if (tcp->internal_state_ & kClosing) {
     tcp->do_delete();

--- a/agents/statsd/src/statsd_endpoint.cc
+++ b/agents/statsd/src/statsd_endpoint.cc
@@ -112,7 +112,8 @@ StatsDEndpoint::StatsDEndpoint(const std::string& protocol,
   : protocol_(protocol),
     hostname_(hostname),
     port_(port),
-    addresses_(addresses) {
+    addresses_(addresses),
+    type_(protocol == "udp" ? Type::Udp : Type::Tcp) {
 }
 
 }  // namespace statsd

--- a/agents/statsd/src/statsd_endpoint.h
+++ b/agents/statsd/src/statsd_endpoint.h
@@ -49,6 +49,13 @@ class StatsDEndpoint {
  public:
   NSOLID_DELETE_UNUSED_CONSTRUCTORS(StatsDEndpoint)
 
+  enum class Type {
+    Tcp,
+    Udp,
+  };
+
+  constexpr Type type() const { return type_; }
+
   static StatsDEndpoint* create(const std::string& addr);
 
   const std::string& protocol() const { return protocol_; }
@@ -78,6 +85,7 @@ class StatsDEndpoint {
   std::string hostname_;
   unsigned int port_;
   std::vector<struct sockaddr_storage> addresses_;
+  Type type_;
 };
 }  // namespace statsd
 }  // namespace nsolid


### PR DESCRIPTION
Make it so StatsDTcp and StatsDUdp inherit from the virtual class StatsDConnection. This way the StatsDAgent only needs to keep a single reference to whichever class is being used. This will also make it easier to have multiple instances of StatsDAgent.