### PR TITLE
agents: add metrics transform API to agent

### DIFF
--- a/agents/statsd/src/binding.cc
+++ b/agents/statsd/src/binding.cc
@@ -68,14 +68,6 @@ static void Send(const FunctionCallbackInfo<Value>& args) {
   args.GetReturnValue().Set(StatsDAgent::Inst()->send(sv, full_size));
 }
 
-static void Start(const FunctionCallbackInfo<Value>& args) {
-  args.GetReturnValue().Set(StatsDAgent::Inst()->start());
-}
-
-static void Stop(const FunctionCallbackInfo<Value>& args) {
-  args.GetReturnValue().Set(StatsDAgent::Inst()->stop());
-}
-
 static void Tags(const FunctionCallbackInfo<Value>& args) {
   Isolate* isolate = args.GetIsolate();
   std::string tags = StatsDAgent::Inst()->tags();
@@ -156,9 +148,7 @@ static void RegisterStatusCb(const FunctionCallbackInfo<Value>& args) {
 static void RegisterExternalReferences(ExternalReferenceRegistry* registry) {
   registry->Register(Bucket);
   registry->Register(Send);
-  registry->Register(Start);
   registry->Register(Status);
-  registry->Register(Stop);
   registry->Register(Tags);
   registry->Register(TcpIp);
   registry->Register(UdpIp);
@@ -178,8 +168,6 @@ void InitStatsDAgent(Local<Object> exports,
 
   NODE_SET_METHOD(exports, "bucket", Bucket);
   NODE_SET_METHOD(exports, "send", Send);
-  NODE_SET_METHOD(exports, "start", Start);
-  NODE_SET_METHOD(exports, "stop", Stop);
   NODE_SET_METHOD(exports, "tags", Tags);
   NODE_SET_METHOD(exports, "tcpIp", TcpIp);
   NODE_SET_METHOD(exports, "udpIp", UdpIp);

--- a/agents/statsd/src/statsd_agent.h
+++ b/agents/statsd/src/statsd_agent.h
@@ -206,9 +206,10 @@ class StatsDAgent: public std::enable_shared_from_this<StatsDAgent> {
 
   int setup_metrics_timer(uint64_t period);
 
+  // TODO(trevnorris): This is only meant to be used by the global instance,
+  // not by the public. Change the way the global instance works so that this
+  // isn't necessary.
   int start();
-
-  int stop();
 
   // Dynamically set the current configuration of the agent.
   // The JSON schema of the currently supported configuration with its

--- a/src/nsolid.cc
+++ b/src/nsolid.cc
@@ -35,6 +35,11 @@ SharedEnvInst GetEnvInst(uint64_t thread_id) {
 }
 
 
+void GetAllEnvInst(std::function<void(SharedEnvInst)> cb) {
+  EnvList::Inst()->getAllEnvInst(cb);
+}
+
+
 SharedEnvInst GetLocalEnvInst(v8::Local<v8::Context> context) {
   return EnvInst::GetCurrent(context);
 }

--- a/src/nsolid.h
+++ b/src/nsolid.h
@@ -358,6 +358,12 @@ NODE_EXTERN void thread_removed_hook_(void*,
 NODE_EXTERN SharedEnvInst GetEnvInst(uint64_t thread_id);
 
 /**
+ * @brief Call cb synchronously with each existing SharedEnvInst instance
+ * currently alive. This call is thread-safe.
+ */
+NODE_EXTERN void GetAllEnvInst(std::function<void(SharedEnvInst)>);
+
+/**
  * @brief Retrieve the SharedEnvInst for the current v8::Context. Must be
  * run from a valid Isolate. This call is not thread-safe.
  *

--- a/src/nsolid/nsolid_api.cc
+++ b/src/nsolid/nsolid_api.cc
@@ -1231,6 +1231,14 @@ void EnvList::UpdateTracingFlags(uint32_t flags) {
 }
 
 
+void EnvList::getAllEnvInst(std::function<void(SharedEnvInst)> cb) {
+  ns_mutex::scoped_lock lock(map_lock_);
+  for (const auto& pair : env_map_) {
+    cb(pair.second);
+  }
+}
+
+
 void EnvList::datapoint_cb_(std::queue<MetricsStream::Datapoint>&& q) {
   // It runs in the nsolid thread
   if (q.empty()) {

--- a/src/nsolid/nsolid_api.h
+++ b/src/nsolid/nsolid_api.h
@@ -542,6 +542,8 @@ class EnvList {
 
   void UpdateTracingFlags(uint32_t flags);
 
+  void getAllEnvInst(std::function<void(SharedEnvInst)>);
+
   inline uv_thread_t thread();
   inline size_t env_map_size();
   inline nsuv::ns_mutex* command_lock();

--- a/test/addons/nsolid-get-all-envinst/binding.cc
+++ b/test/addons/nsolid-get-all-envinst/binding.cc
@@ -1,0 +1,23 @@
+#include <node.h>
+#include <v8.h>
+#include <uv.h>
+#include <nsolid.h>
+
+#include <assert.h>
+#include <atomic>
+
+using v8::FunctionCallbackInfo;
+using v8::Value;
+
+void CheckEnvCount(const FunctionCallbackInfo<Value>& args) {
+  int len = 0;
+  node::nsolid::GetAllEnvInst([&len](node::nsolid::SharedEnvInst) {
+    len++;
+  });
+  args.GetReturnValue().Set(len);
+}
+
+
+NODE_MODULE_INIT(/* exports, module, context */) {
+  NODE_SET_METHOD(exports, "checkEnvCount", CheckEnvCount);
+}

--- a/test/addons/nsolid-get-all-envinst/binding.gyp
+++ b/test/addons/nsolid-get-all-envinst/binding.gyp
@@ -1,0 +1,16 @@
+{
+  'targets': [{
+    'target_name': 'binding',
+    'sources': [ 'binding.cc' ],
+    'includes': ['../common.gypi'],
+    'target_defaults': {
+      'default_configuration': 'Release',
+      'configurations': {
+        'Debug': {
+          'defines': [ 'DEBUG', '_DEBUG' ],
+          'cflags': [ '-g', '-O0', '-fstandalone-debug' ],
+        }
+      },
+    },
+  }],
+}

--- a/test/addons/nsolid-get-all-envinst/nsolid-get-all-envinst.js
+++ b/test/addons/nsolid-get-all-envinst/nsolid-get-all-envinst.js
@@ -1,0 +1,35 @@
+'use strict';
+
+const { buildType, mustCall, skip } = require('../../common');
+const assert = require('assert');
+const bindingPath = require.resolve(`./build/${buildType}/binding`);
+const binding = require(bindingPath);
+const { Worker, isMainThread, parentPort } = require('worker_threads');
+const workerList = [];
+
+if (process.env.NSOLID_COMMAND)
+  skip('required to run without the Console');
+
+if (!isMainThread && +process.argv[2] !== process.pid)
+  skip('Test must first run as the main thread');
+
+if (isMainThread) {
+  spawnWorker();
+} else {
+  parentPort.on('message', () => process.exit());
+}
+
+function spawnWorker() {
+  if (workerList.length > 4) {
+    for (let w of workerList)
+      w.postMessage('bye');
+    return;
+  }
+  const w = new Worker(__filename, { argv: [process.pid] });
+  w.on('online', () => {
+    // Add 1 for the main thread.
+    assert.strictEqual(binding.checkEnvCount(), workerList.length + 1);
+    spawnWorker();
+  });
+  workerList.push(w);
+}

--- a/test/addons/nsolid-statsdagent/binding.cc
+++ b/test/addons/nsolid-statsdagent/binding.cc
@@ -1,0 +1,75 @@
+#include <node.h>
+#include <v8.h>
+#include <uv.h>
+#include <nsolid.h>
+#include <statsd_agent.h>
+
+#include <assert.h>
+#include <atomic>
+
+using v8::FunctionCallbackInfo;
+using v8::String;
+using v8::Value;
+
+using node::nsolid::ProcessMetrics;
+using node::nsolid::ThreadMetrics;
+using node::nsolid::statsd::SharedStatsDAgent;
+using node::nsolid::statsd::StatsDAgent;
+
+SharedStatsDAgent agent;
+
+static std::vector<std::string> pm(ProcessMetrics::MetricsStor stor) {
+  std::vector<std::string> sv;
+  std::string ms = "";
+#define V(Type, CName, JSName, MType, Unit)                                    \
+  ms = "proc.";                                                                \
+  ms += #JSName ":";                                                           \
+  ms += isnan(stor.CName) ?  "null" : std::to_string(stor.CName);              \
+  ms += "|g\n";                                                                \
+  sv.push_back(ms);
+  NSOLID_PROCESS_METRICS_NUMBERS(V)
+#undef V
+  return sv;
+}
+
+static std::vector<std::string> tm(ThreadMetrics::MetricsStor stor) {
+  std::vector<std::string> sv;
+  std::string ms = "";
+#define V(Type, CName, JSName, MType, Unit)                                    \
+  ms = "thread.";                                                              \
+  ms += #JSName ":";                                                           \
+  ms += isnan(stor.CName) ?  "null" : std::to_string(stor.CName);              \
+  ms += "|g|#threadId:";                                                       \
+  ms += std::to_string(stor.thread_id);                                        \
+  ms += "\n";                                                                  \
+  sv.push_back(ms);
+  NSOLID_ENV_METRICS_NUMBERS(V)
+#undef V
+  return sv;
+}
+
+static void SetAddHooks(const FunctionCallbackInfo<Value>& args) {
+  assert(args[0]->IsString());
+  const String::Utf8Value url(args.GetIsolate(), args[0]);
+  agent = node::nsolid::statsd::StatsDAgent::Create();
+  agent->config({{"statsd", *url},
+                 {"interval", 3000},
+                 {"pauseMetrics", false}});
+  agent->set_pmetrics_transform_cb(pm);
+  agent->set_tmetrics_transform_cb(tm);
+}
+
+static void GetStatus(const FunctionCallbackInfo<Value>& args) {
+  if (!agent)
+    return args.GetReturnValue().SetNull();
+  args.GetReturnValue().Set(String::NewFromOneByte(
+        args.GetIsolate(),
+        reinterpret_cast<const uint8_t*>(agent->status().c_str()),
+        v8::NewStringType::kNormal).ToLocalChecked());
+}
+
+
+NODE_MODULE_INIT(/* exports, module, context */) {
+  NODE_SET_METHOD(exports, "setAddHooks", SetAddHooks);
+  NODE_SET_METHOD(exports, "getStatus", GetStatus);
+}

--- a/test/addons/nsolid-statsdagent/binding.gyp
+++ b/test/addons/nsolid-statsdagent/binding.gyp
@@ -1,0 +1,22 @@
+{
+  'targets': [{
+    'target_name': 'binding',
+    'sources': [ 'binding.cc' ],
+    'includes': ['../common.gypi'],
+    'defines': [ 'NODE_WANT_INTERNALS=1' ],
+    'include_dirs': [
+      '../../../src/',
+      '../../../deps/nsuv/include/',
+      '../../../agents/statsd/src/',
+    ],
+    'target_defaults': {
+      'default_configuration': 'Release',
+      'configurations': {
+        'Debug': {
+          'defines': [ 'DEBUG', '_DEBUG' ],
+          'cflags': [ '-g', '-O0', '-fstandalone-debug' ],
+        }
+      },
+    },
+  }],
+}

--- a/test/addons/nsolid-statsdagent/nsolid-statsdagent.js
+++ b/test/addons/nsolid-statsdagent/nsolid-statsdagent.js
@@ -1,0 +1,138 @@
+'use strict';
+
+const { buildType, mustCall, mustCallAtLeast, skip } = require('../../common');
+const assert = require('assert');
+const bindingPath = require.resolve(`./build/${buildType}/binding`);
+const binding = require(bindingPath);
+const net = require('net');
+const { Worker, isMainThread } = require('worker_threads');
+
+let expectedProcMetrics = [
+  'timestamp',
+  'uptime',
+  'systemUptime',
+  'freeMem',
+  'blockInputOpCount',
+  'blockOutputOpCount',
+  'ctxSwitchInvoluntaryCount',
+  'ctxSwitchVoluntaryCount',
+  'ipcReceivedCount',
+  'ipcSentCount',
+  'pageFaultHardCount',
+  'pageFaultSoftCount',
+  'signalCount',
+  'swapCount',
+  'rss',
+  'load1m',
+  'load5m',
+  'load15m',
+  'cpuUserPercent',
+  'cpuSystemPercent',
+  'cpuPercent',
+];
+
+let expectedThreadMetrics = [
+  'threadId',
+  'timestamp',
+  'activeHandles',
+  'activeRequests',
+  'heapTotal',
+  'totalHeapSizeExecutable',
+  'totalPhysicalSize',
+  'totalAvailableSize',
+  'heapUsed',
+  'heapSizeLimit',
+  'mallocedMemory',
+  'externalMem',
+  'peakMallocedMemory',
+  'numberOfNativeContexts',
+  'numberOfDetachedContexts',
+  'gcCount',
+  'gcForcedCount',
+  'gcFullCount',
+  'gcMajorCount',
+  'dnsCount',
+  'httpClientAbortCount',
+  'httpClientCount',
+  'httpServerAbortCount',
+  'httpServerCount',
+  'loopIdleTime',
+  'loopIterations',
+  'loopIterWithEvents',
+  'eventsProcessed',
+  'eventsWaiting',
+  'providerDelay',
+  'processingDelay',
+  'loopTotalCount',
+  'pipeServerCreatedCount',
+  'pipeServerDestroyedCount',
+  'pipeSocketCreatedCount',
+  'pipeSocketDestroyedCount',
+  'tcpServerCreatedCount',
+  'tcpServerDestroyedCount',
+  'tcpSocketCreatedCount',
+  'tcpSocketDestroyedCount',
+  'udpSocketCreatedCount',
+  'udpSocketDestroyedCount',
+  'promiseCreatedCount',
+  'promiseResolvedCount',
+  'fsHandlesOpenedCount',
+  'fsHandlesClosedCount',
+  'gcDurUs99Ptile',
+  'gcDurUsMedian',
+  'dns99Ptile',
+  'dnsMedian',
+  'httpClient99Ptile',
+  'httpClientMedian',
+  'httpServer99Ptile',
+  'httpServerMedian',
+  'loopUtilization',
+  'res5s',
+  'res1m',
+  'res5m',
+  'res15m',
+  'loopAvgTasks',
+  'loopEstimatedLag',
+  'loopIdlePercent',
+];
+
+if (process.env.NSOLID_COMMAND)
+  skip('required to run without the Console');
+
+if (!isMainThread)
+  skip('Test must be run as the main thread');
+
+const server = net.createServer(mustCall((socket) => {
+  assert.strictEqual(binding.getStatus(), 'ready');
+  socket.on('data', mustCallAtLeast((d) => {
+    const lines = d.toString()
+      .split('\n')
+      .filter(e => e.length > 0)
+      .map(e => e.split('|'));
+    for (let e of lines) {
+      const s = e[0].split('.');
+      const m = s[1].split(':')[0];
+      if (s[0] === 'proc') {
+        assert.ok(expectedProcMetrics.includes(m), m);
+        expectedProcMetrics = expectedProcMetrics.filter((x) => x !== m);
+      } else if (s[0] === 'thread') {
+        assert.ok(expectedThreadMetrics.includes(m), m);
+        expectedThreadMetrics = expectedThreadMetrics.filter((x) => x !== m);
+      } else {
+        assert.fail('unreachable');
+      }
+    }
+    // All metrics have been found. Test is complete.
+    if (expectedThreadMetrics.length === 0 &&
+        expectedProcMetrics.length === 0) {
+      process.exit();
+    }
+  }, 2));
+}));
+
+server.listen(0, '127.0.0.1', mustCall(() => {
+  binding.setAddHooks(`tcp://127.0.0.1:${server.address().port}`);
+  assert.strictEqual(binding.getStatus(), 'initializing');
+}));
+
+assert.strictEqual(binding.getStatus(), null);


### PR DESCRIPTION
Allow users to register a callback that will transform the metrics into a std::string that will be written to the endpoint.

Still working on tests.