### PR TITLE
agents: get telemetry data even if no cmd handle

### DIFF
--- a/agents/zmq/src/zmq_agent.cc
+++ b/agents/zmq/src/zmq_agent.cc
@@ -1434,26 +1434,24 @@ int ZmqAgent::config(const json& config) {
     setup_blocked_loop_hooks();
   }
 
-  // Return early if command handle is not to be configured
-  if (command_handle_ == nullptr) {
-    return 0;
-  }
-
-  if (ZmqHandle::needs_reset(diff, ZmqDataHandle::restart_fields)) {
-    data_handle_.reset(nullptr);
-    auto data = ZmqDataHandle::create(*this, config_);
-    ret = std::get<int>(data);
-    if (ret == 0) {
-      data_handle_.reset(std::get<ZmqDataHandle*>(data));
+  // Don't config other endpoints if command handle is not to be configured
+  if (command_handle_ != nullptr) {
+    if (ZmqHandle::needs_reset(diff, ZmqDataHandle::restart_fields)) {
+      data_handle_.reset(nullptr);
+      auto data = ZmqDataHandle::create(*this, config_);
+      ret = std::get<int>(data);
+      if (ret == 0) {
+        data_handle_.reset(std::get<ZmqDataHandle*>(data));
+      }
     }
-  }
 
-  if (ZmqHandle::needs_reset(diff, ZmqBulkHandle::restart_fields)) {
-    bulk_handle_.reset(nullptr);
-    auto bulk = ZmqBulkHandle::create(*this, config_);
-    ret = std::get<int>(bulk);
-    if (ret == 0) {
-      bulk_handle_.reset(std::get<ZmqBulkHandle*>(bulk));
+    if (ZmqHandle::needs_reset(diff, ZmqBulkHandle::restart_fields)) {
+      bulk_handle_.reset(nullptr);
+      auto bulk = ZmqBulkHandle::create(*this, config_);
+      ret = std::get<int>(bulk);
+      if (ret == 0) {
+        bulk_handle_.reset(std::get<ZmqBulkHandle*>(bulk));
+      }
     }
   }
 

--- a/test/common/nsolid-zmq-agent/client.js
+++ b/test/common/nsolid-zmq-agent/client.js
@@ -7,6 +7,10 @@ const nsolid = require('nsolid');
 const { fixturesDir } = require('../fixtures');
 
 const options = {
+  trace: {
+    type: 'string',
+    short: 't',
+  },
   workers: {
     type: 'string',
     short: 'w',
@@ -140,6 +144,20 @@ if (isMainThread) {
         const worker = new Worker(__filename);
         workers.set(worker.threadId, worker);
       }
+    }
+  }
+
+  if (args.values.trace) {
+    const trace = args.values.trace;
+    if (trace === 'http') {
+      // TODO(santigimeno): ideally we should be able to collect traces
+      // immediately without the need of calling nsolid.start()
+      nsolid.start();
+      execHttpTransaction();
+    } else if (trace === 'dns') {
+      execDnsTransaction();
+    } else if (trace === 'custom') {
+      execCustomTrace();
     }
   }
 } else {


### PR DESCRIPTION
We want the ZmqAgent to collect data (traces and/or metrics) even if the ZMQ channels aren't fully up. This wasn't happening and we were losing data because the tracing and metrics configuration options were not handled until the ZmqCommandHandle wasn't ready.

Ideally we should be able to collect traces even on initial loop iteration without the need of calling `nsolid.start()`.  This should go into a follow-up PR though.

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
