### PR TITLE
test: fix flaky test when run under load

### DIFF
--- a/test/addons/nsolid-statsdagent/nsolid-statsdagent.js
+++ b/test/addons/nsolid-statsdagent/nsolid-statsdagent.js
@@ -127,12 +127,11 @@ const server = net.createServer(mustCall((socket) => {
         expectedProcMetrics.length === 0) {
       process.exit();
     }
-  }, 2));
+  }, 1));
 }));
 
 server.listen(0, '127.0.0.1', mustCall(() => {
   binding.setAddHooks(`tcp://127.0.0.1:${server.address().port}`);
-  assert.strictEqual(binding.getStatus(), 'initializing');
 }));
 
 assert.strictEqual(binding.getStatus(), null);


### PR DESCRIPTION
Running the test with the following:

    $ ./tools/test.py -J --repeat=100 test/addons/nsolid-statsdagent/nsolid-statsdagent.js

caused the test to fail in various ways. The fix takes into account that when the test is slowed down under load it's possible for the StatsDAgent instance to be ready before it can be checked in JS, and that the data might have been placed into a single call to 'data'.

Fixes: https://github.com/nodesource/nsolid/issues/142