### PR TITLE
[v18.x] src: initialize prev_idle_time_ on ThreadMetrics

### DIFF
--- a/src/nsolid.cc
+++ b/src/nsolid.cc
@@ -285,6 +285,7 @@ ThreadMetrics::ThreadMetrics(SharedEnvInst envinst)
   stor_.thread_id = thread_id_;
   stor_.prev_call_time_ = uv_hrtime();
   stor_.current_hrtime_ = stor_.prev_call_time_;
+  stor_.prev_idle_time_ = uv_metrics_idle_time(envinst->event_loop());
 }
 
 
@@ -300,6 +301,8 @@ ThreadMetrics::ThreadMetrics(uint64_t thread_id)
   stor_.thread_id = thread_id_;
   stor_.prev_call_time_ = uv_hrtime();
   stor_.current_hrtime_ = stor_.prev_call_time_;
+  // Letting prev_idle_time_ be 0 is ok as this is only used by the EnvInst
+  // constructor.
 }
 
 

--- a/test/addons/nsolid-env-metrics/binding.cc
+++ b/test/addons/nsolid-env-metrics/binding.cc
@@ -16,6 +16,7 @@ struct Metrics {
 
 static void got_env_metrics(SharedThreadMetrics tm_sp, Metrics* m) {
   assert(tm_sp == m->tm);
+  assert(tm_sp->Get().loop_utilization <= 1);
   cb_cntr++;
   delete m;
 }

--- a/test/addons/nsolid-env-metrics/nsolid-env-metrics.js
+++ b/test/addons/nsolid-env-metrics/nsolid-env-metrics.js
@@ -37,4 +37,8 @@ for (let i = 0; i < 10; i++) {
   }));
 }
 
-binding.getMetrics();
+// Let then main thread be a bit idle so we can check that loop_utilization is
+// correctly calculdate.
+setTimeout(() => {
+  binding.getMetrics();
+}, 100);


### PR DESCRIPTION
Make sure `prev_idle_time_` is initialized in the
`ThreadMetrics::ThreadMetrics(SharedEnvInst envinst)` constructor so the loop utilization calculations are correct, otherwise the default value 0 is used which may lead to meaningless huge values (greater than 1 for the matter).
No need to initialize this value in the
`ThreadMetrics::ThreadMetrics(uint64_t thread_id)` as this is only used in the `EnvInst` constructor on which having a value of 0 makes sense.

PR-URL: https://github.com/nodesource/nsolid/pull/156
Reviewed-by: Trevor Norris <trev.norris@gmail.com>
Reviewed-by: Juan José Arboleda <soyjuanarbol@gmail.com>

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
