### PR TITLE
src: add deps to process.versions

### DIFF
--- a/src/node_metadata.cc
+++ b/src/node_metadata.cc
@@ -1,4 +1,5 @@
 #include "node_metadata.h"
+#include <zmq.h>
 #include "acorn_version.h"
 #include "ada.h"
 #include "ares.h"
@@ -143,6 +144,12 @@ Metadata::Versions::Versions() {
     "."
     NODE_STRINGIFY(NLOHMANN_JSON_VERSION_PATCH);
   opentelemetry = OPENTELEMETRY_VERSION;
+  zmq =
+    NODE_STRINGIFY(ZMQ_VERSION_MAJOR)
+    "."
+    NODE_STRINGIFY(ZMQ_VERSION_MINOR)
+    "."
+    NODE_STRINGIFY(ZMQ_VERSION_PATCH);
 }
 
 Metadata::Release::Release() : name(NODE_RELEASE) {

--- a/src/node_metadata.cc
+++ b/src/node_metadata.cc
@@ -10,6 +10,7 @@
 #include "nghttp2/nghttp2ver.h"
 #include "nlohmann/json.h"
 #include "node.h"
+#include "opentelemetry/version.h"
 #include "simdutf.h"
 #include "undici_version.h"
 #include "util.h"
@@ -141,6 +142,7 @@ Metadata::Versions::Versions() {
     NODE_STRINGIFY(NLOHMANN_JSON_VERSION_MINOR)
     "."
     NODE_STRINGIFY(NLOHMANN_JSON_VERSION_PATCH);
+  opentelemetry = OPENTELEMETRY_VERSION;
 }
 
 Metadata::Release::Release() : name(NODE_RELEASE) {

--- a/src/node_metadata.cc
+++ b/src/node_metadata.cc
@@ -20,6 +20,7 @@
 #include "uvwasi.h"
 #include "v8.h"
 #include "sodium/version.h"
+#include <google/protobuf/message.h>
 
 #ifdef NODE_BUNDLED_ZLIB
 #include "zlib_version.h"
@@ -154,6 +155,7 @@ Metadata::Versions::Versions() {
     "."
     NODE_STRINGIFY(ZMQ_VERSION_PATCH);
   sodium = SODIUM_VERSION_STRING;
+  protobuf = google::protobuf::internal::VersionString(GOOGLE_PROTOBUF_VERSION);
 }
 
 Metadata::Release::Release() : name(NODE_RELEASE) {

--- a/src/node_metadata.cc
+++ b/src/node_metadata.cc
@@ -19,6 +19,7 @@
 #include "uv.h"
 #include "uvwasi.h"
 #include "v8.h"
+#include "sodium/version.h"
 
 #ifdef NODE_BUNDLED_ZLIB
 #include "zlib_version.h"
@@ -152,6 +153,7 @@ Metadata::Versions::Versions() {
     NODE_STRINGIFY(ZMQ_VERSION_MINOR)
     "."
     NODE_STRINGIFY(ZMQ_VERSION_PATCH);
+  sodium = SODIUM_VERSION_STRING;
 }
 
 Metadata::Release::Release() : name(NODE_RELEASE) {

--- a/src/node_metadata.cc
+++ b/src/node_metadata.cc
@@ -7,6 +7,7 @@
 #include "brotli/encode.h"
 #include "cjs_module_lexer_version.h"
 #include "curl/curlver.h"
+#include "grpcpp/version_info.h"
 #include "llhttp.h"
 #include "nghttp2/nghttp2ver.h"
 #include "nlohmann/json.h"
@@ -137,6 +138,7 @@ Metadata::Versions::Versions() {
   simdutf = SIMDUTF_VERSION;
   ada = ADA_VERSION;
   curl = LIBCURL_VERSION;
+  grpc = GRPC_CPP_VERSION_STRING;
   nlohmann =
     NODE_STRINGIFY(NLOHMANN_JSON_VERSION_MAJOR)
     "."

--- a/src/node_metadata.cc
+++ b/src/node_metadata.cc
@@ -8,6 +8,7 @@
 #include "curl/curlver.h"
 #include "llhttp.h"
 #include "nghttp2/nghttp2ver.h"
+#include "nlohmann/json.h"
 #include "node.h"
 #include "simdutf.h"
 #include "undici_version.h"
@@ -134,6 +135,12 @@ Metadata::Versions::Versions() {
   simdutf = SIMDUTF_VERSION;
   ada = ADA_VERSION;
   curl = LIBCURL_VERSION;
+  nlohmann =
+    NODE_STRINGIFY(NLOHMANN_JSON_VERSION_MAJOR)
+    "."
+    NODE_STRINGIFY(NLOHMANN_JSON_VERSION_MINOR)
+    "."
+    NODE_STRINGIFY(NLOHMANN_JSON_VERSION_PATCH);
 }
 
 Metadata::Release::Release() : name(NODE_RELEASE) {

--- a/src/node_metadata.cc
+++ b/src/node_metadata.cc
@@ -5,6 +5,7 @@
 #include "base64_version.h"
 #include "brotli/encode.h"
 #include "cjs_module_lexer_version.h"
+#include "curl/curlver.h"
 #include "llhttp.h"
 #include "nghttp2/nghttp2ver.h"
 #include "node.h"
@@ -132,6 +133,7 @@ Metadata::Versions::Versions() {
 
   simdutf = SIMDUTF_VERSION;
   ada = ADA_VERSION;
+  curl = LIBCURL_VERSION;
 }
 
 Metadata::Release::Release() : name(NODE_RELEASE) {

--- a/src/node_metadata.h
+++ b/src/node_metadata.h
@@ -56,6 +56,7 @@ namespace node {
   NODE_VERSIONS_KEY_UNDICI(V)                                                  \
   V(cjs_module_lexer)                                                          \
   V(curl)                                                                      \
+  V(nlohmann)                                                                  \
   V(base64)
 
 #if HAVE_OPENSSL

--- a/src/node_metadata.h
+++ b/src/node_metadata.h
@@ -57,6 +57,7 @@ namespace node {
   V(cjs_module_lexer)                                                          \
   V(curl)                                                                      \
   V(grpc)                                                                      \
+  V(sodium)                                                                    \
   V(nlohmann)                                                                  \
   V(opentelemetry)                                                             \
   V(zmq)                                                                       \

--- a/src/node_metadata.h
+++ b/src/node_metadata.h
@@ -58,6 +58,7 @@ namespace node {
   V(curl)                                                                      \
   V(grpc)                                                                      \
   V(sodium)                                                                    \
+  V(protobuf)                                                                  \
   V(nlohmann)                                                                  \
   V(opentelemetry)                                                             \
   V(zmq)                                                                       \

--- a/src/node_metadata.h
+++ b/src/node_metadata.h
@@ -55,6 +55,7 @@ namespace node {
   V(ada)                                                                       \
   NODE_VERSIONS_KEY_UNDICI(V)                                                  \
   V(cjs_module_lexer)                                                          \
+  V(curl)                                                                      \
   V(base64)
 
 #if HAVE_OPENSSL

--- a/src/node_metadata.h
+++ b/src/node_metadata.h
@@ -58,6 +58,7 @@ namespace node {
   V(curl)                                                                      \
   V(nlohmann)                                                                  \
   V(opentelemetry)                                                             \
+  V(zmq)                                                                       \
   V(base64)
 
 #if HAVE_OPENSSL

--- a/src/node_metadata.h
+++ b/src/node_metadata.h
@@ -57,6 +57,7 @@ namespace node {
   V(cjs_module_lexer)                                                          \
   V(curl)                                                                      \
   V(nlohmann)                                                                  \
+  V(opentelemetry)                                                             \
   V(base64)
 
 #if HAVE_OPENSSL

--- a/src/node_metadata.h
+++ b/src/node_metadata.h
@@ -56,6 +56,7 @@ namespace node {
   NODE_VERSIONS_KEY_UNDICI(V)                                                  \
   V(cjs_module_lexer)                                                          \
   V(curl)                                                                      \
+  V(grpc)                                                                      \
   V(nlohmann)                                                                  \
   V(opentelemetry)                                                             \
   V(zmq)                                                                       \

--- a/test/parallel/test-process-versions.js
+++ b/test/parallel/test-process-versions.js
@@ -28,6 +28,7 @@ const expected_keys = [
   'nlohmann',
   'opentelemetry',
   'zmq',
+  'sodium',
 ];
 
 const hasUndici = process.config.variables.node_builtin_shareable_builtins.includes('deps/undici/undici.js');

--- a/test/parallel/test-process-versions.js
+++ b/test/parallel/test-process-versions.js
@@ -24,6 +24,7 @@ const expected_keys = [
   'cjs_module_lexer',
   'base64',
   'curl',
+  'grpc',
   'nlohmann',
   'opentelemetry',
   'zmq',

--- a/test/parallel/test-process-versions.js
+++ b/test/parallel/test-process-versions.js
@@ -23,6 +23,7 @@ const expected_keys = [
   'ada',
   'cjs_module_lexer',
   'base64',
+  'curl',
 ];
 
 const hasUndici = process.config.variables.node_builtin_shareable_builtins.includes('deps/undici/undici.js');

--- a/test/parallel/test-process-versions.js
+++ b/test/parallel/test-process-versions.js
@@ -29,6 +29,7 @@ const expected_keys = [
   'opentelemetry',
   'zmq',
   'sodium',
+  'protobuf',
 ];
 
 const hasUndici = process.config.variables.node_builtin_shareable_builtins.includes('deps/undici/undici.js');

--- a/test/parallel/test-process-versions.js
+++ b/test/parallel/test-process-versions.js
@@ -26,6 +26,7 @@ const expected_keys = [
   'curl',
   'nlohmann',
   'opentelemetry',
+  'zmq',
 ];
 
 const hasUndici = process.config.variables.node_builtin_shareable_builtins.includes('deps/undici/undici.js');

--- a/test/parallel/test-process-versions.js
+++ b/test/parallel/test-process-versions.js
@@ -24,6 +24,7 @@ const expected_keys = [
   'cjs_module_lexer',
   'base64',
   'curl',
+  'nlohmann',
 ];
 
 const hasUndici = process.config.variables.node_builtin_shareable_builtins.includes('deps/undici/undici.js');

--- a/test/parallel/test-process-versions.js
+++ b/test/parallel/test-process-versions.js
@@ -25,6 +25,7 @@ const expected_keys = [
   'base64',
   'curl',
   'nlohmann',
+  'opentelemetry',
 ];
 
 const hasUndici = process.config.variables.node_builtin_shareable_builtins.includes('deps/undici/undici.js');


### PR DESCRIPTION
Fixes: https://github.com/nodesource/nsolid/issues/163

New dependency list:

- [ ] asserts-cpp - I didn't think is a valid addition to process.versions as it doesn't really seem a dependency but a helper in the wrong folder.
- [x] curl
- [x] gprc - This is a third-party dependency - We use it through opentelemetry. The only reason it's top level dependency was to fix a windows linker issue
- [x] nlohmann
- [ ] ncm-ng - It doesn't seem like a nsolid runtime dependency, but an alternate binary if I'm reading https://github.com/nodesource/nsolid/issues/163 correctly. Therefore, it doesn't seem to apply to `process.versions`.
- [x] nsolid-cli - Already covered
- [ ] nsuv - This library doesn't hold VERSION information, so at the moment I decided to not include it and work on this in that repo.
- [x] opentelemetry-cpp
- [x] protobuf - Same as `grpc`.
- [x] sodium - Same as `grpc`
- [x] zmq

Note we are extracting the version directly in the deps/ folder. The Node.js sometimes create a `src/X_version.` and update it through `tools/updater.sh`. If you prefer I can do that, but it will require creating an updater for all of our dependency (I was planning to do it in a second PR).
