### PR TITLE
src: fix heapSampling crash if sampleInterval is 0

### DIFF
--- a/src/nsolid/nsolid_heap_snapshot.cc
+++ b/src/nsolid/nsolid_heap_snapshot.cc
@@ -19,6 +19,11 @@ int NSolidHeapSnapshot::StartSamplingProfiler(
     uint64_t duration,
     internal::user_data data,
     Snapshot::snapshot_proxy_sig proxy) {
+  // Using a sampleInterval of 0 causes a v8 crash.
+  if (sample_interval == 0) {
+    return UV_EINVAL;
+  }
+
   uint64_t thread_id = envinst->thread_id();
   uint64_t snaphot_id =
     in_progress_timers_.fetch_add(1, std::memory_order_relaxed);

--- a/test/parallel/test-nsolid-heap-sampling-stream.js
+++ b/test/parallel/test-nsolid-heap-sampling-stream.js
@@ -7,6 +7,7 @@ const nsolid = require('nsolid');
 const { internalBinding } = require('internal/test/binding');
 
 const {
+  UV_EINVAL,
   UV_ESRCH,
 } = internalBinding('uv');
 
@@ -96,6 +97,17 @@ const {
   stream.on('error', common.mustCall((err) => {
     assert.strictEqual(err.message, 'Heap sampling could not be started');
     assert.strictEqual(err.code, UV_ESRCH);
+  }));
+}
+
+{
+  // Using a sampleInterval of 0 should result in an error as it causes a crash
+  // on v8.
+  const opts = { sampleInterval: 0 };
+  const stream = nsolid.heapSamplingStream(0, 12000, opts);
+  stream.on('error', common.mustCall((err) => {
+    assert.strictEqual(err.message, 'Heap sampling could not be started');
+    assert.strictEqual(err.code, UV_EINVAL);
   }));
 }
 


### PR DESCRIPTION
Caused by this [check](https://github.com/nodesource/nsolid/blob/3ea993c2e333ca13063bffecd518134b7849d692/deps/v8/src/profiler/sampling-heap-profiler.cc#L64) in v8 source code.

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
