### PR TITLE
build: disable get-released-versions for nsolid

### DIFF
--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -67,7 +67,7 @@ jobs:
       - name: Lint JavaScript files
         run: NODE=$(command -v node) make lint-js
       - name: Get release version numbers
-        if: ${{ github.event.pull_request && github.event.pull_request.base.ref == github.event.pull_request.base.repo.default_branch }}
+        if: ${{ github.event.pull_request && github.event.pull_request.base.ref == github.event.pull_request.base.repo.default_branch && false }}
         id: get-released-versions
         run: ./tools/lint-md/list-released-versions-from-changelogs.mjs >> $GITHUB_OUTPUT
       - name: Lint markdown files


### PR DESCRIPTION
This commit disables get-released-versions comparison as our base branch (node-vN.x-nsolid-vX.x) isn't the same as Node.js (main). So, the check expects that we are running into the `main` branch where all release commits go to (so the changelog) is up to date.

Basically, there are two ways of solving it:

1. Disabling the workflow
2. Keep our default branch in sync with all release commits from old release lines. For instance, whenever v18 gets a new version, we need to cherry-pick it. Example: `git cherry-pick e922fb64b53530af4ad2e3df298a302225645f5b`. But, it seems annoying work for almost no gain (considering we never float a new API to Node.js modules).

So, I think the viable solution is just disabling the versions lint (Markdown and JS files will always work). This check is just to guarantee that the version specified in the API (e.g. added: v99.99) exists in the CHANGELOG. 