### PR TITLE
build: enable commit-queue

### DIFF
--- a/.github/workflows/commit-queue.yml
+++ b/.github/workflows/commit-queue.yml
@@ -25,7 +25,7 @@ jobs:
   get_mergeable_prs:
     permissions:
       pull-requests: read
-    if: github.repository == 'nodejs/node'
+    if: github.repository == 'nodesource/nsolid'
     runs-on: ubuntu-latest
     outputs:
       numbers: ${{ steps.get_mergeable_prs.outputs.numbers }}


### PR DESCRIPTION
Fixes: #183 

@riosje This workflow requires:

*  GH_USER_TOKEN - GitHub user token, to be used by ncu and to push changes

~Do we have an existing token or should I create it?~ Done