### PR TITLE
agents: fix ZmqAgent asset JS API

### DIFF
--- a/agents/src/profile_collector.cc
+++ b/agents/src/profile_collector.cc
@@ -4,6 +4,20 @@
 namespace node {
 namespace nsolid {
 
+const char* ProfileTypeStr[kNumberOfProfileTypes] = {
+  "profile",
+  "heap_profile",
+  "heap_sampling",
+  "snapshot"
+};
+
+const char* ProfileTypeStopStr[kNumberOfProfileTypes] = {
+  "profile_stop",
+  "heap_profile_stop",
+  "heap_sampling_stop",
+  ""
+};
+
 ProfileCollector::~ProfileCollector() {
   profile_msg_->close_and_delete();
 }
@@ -38,6 +52,15 @@ int ProfileCollector::StartHeapSampling(const HeapSamplingOptions& options) {
                                  kHeapSampl,
                                  options,
                                  weak_from_this());
+}
+
+int ProfileCollector::StartHeapSnapshot(const HeapSnapshotOptions& options) {
+  return Snapshot::TakeSnapshot(GetEnvInst(options.thread_id),
+                                options.redacted,
+                                profile_cb,
+                                kHeapSnapshot,
+                                options,
+                                weak_from_this());
 }
 
 /*static*/

--- a/agents/src/profile_collector.h
+++ b/agents/src/profile_collector.h
@@ -20,8 +20,12 @@ enum ProfileType {
   kCpu = 0,
   kHeapProf,
   kHeapSampl,
+  kHeapSnapshot,
   kNumberOfProfileTypes
 };
+
+extern const char* ProfileTypeStr[kNumberOfProfileTypes];
+extern const char* ProfileTypeStopStr[kNumberOfProfileTypes];
 
 struct ProfileOptionsBase {
   uint64_t thread_id;
@@ -42,9 +46,14 @@ struct HeapSamplingOptions: public ProfileOptionsBase {
   v8::HeapProfiler::SamplingFlags flags = v8::HeapProfiler::kSamplingNoFlags;
 };
 
+struct HeapSnapshotOptions: public ProfileOptionsBase {
+  bool redacted = false;
+};
+
 using ProfileOptions = std::variant<CPUProfileOptions,
                                     HeapProfileOptions,
-                                    HeapSamplingOptions>;
+                                    HeapSamplingOptions,
+                                    HeapSnapshotOptions>;
 
 
 /*
@@ -76,6 +85,7 @@ class ProfileCollector: public std::enable_shared_from_this<ProfileCollector> {
   int StartCPUProfile(const CPUProfileOptions& options);
   int StartHeapProfile(const HeapProfileOptions& options);
   int StartHeapSampling(const HeapSamplingOptions& options);
+  int StartHeapSnapshot(const HeapSnapshotOptions& options);
 
  private:
   static void profile_cb(int status,

--- a/agents/zmq/src/binding.cc
+++ b/agents/zmq/src/binding.cc
@@ -53,7 +53,8 @@ static void Snapshot(const FunctionCallbackInfo<Value>& args) {
     }}
   };
 
-  args.GetReturnValue().Set(ZmqAgent::Inst()->generate_snapshot(message));
+  args.GetReturnValue().Set(
+    ZmqAgent::Inst()->start_heap_snapshot_from_js(message));
 }
 
 static void StartCPUProfile(const FunctionCallbackInfo<Value>& args) {
@@ -73,14 +74,12 @@ static void StartCPUProfile(const FunctionCallbackInfo<Value>& args) {
     }}
   };
 
-  args.GetReturnValue().Set(ZmqAgent::Inst()->start_profiling(message));
+  args.GetReturnValue().Set(ZmqAgent::Inst()->start_profiling_from_js(message));
 }
 
 static void EndCPUProfile(const FunctionCallbackInfo<Value>& args) {
-  Isolate* isolate = args.GetIsolate();
-  Local<Context> context = isolate->GetCurrentContext();
-  uint64_t thread_id = ThreadId(context);
-  args.GetReturnValue().Set(ZmqAgent::Inst()->stop_profiling(thread_id));
+  args.GetReturnValue().Set(
+    CpuProfiler::StopProfileSync(GetLocalEnvInst(args.GetIsolate())));
 }
 
 static void StartHeapProfile(const FunctionCallbackInfo<Value>& args) {
@@ -103,14 +102,13 @@ static void StartHeapProfile(const FunctionCallbackInfo<Value>& args) {
     }}
   };
 
-  args.GetReturnValue().Set(ZmqAgent::Inst()->start_heap_profiling(message));
+  args.GetReturnValue().Set(
+    ZmqAgent::Inst()->start_heap_profiling_from_js(message));
 }
 
 static void EndHeapProfile(const FunctionCallbackInfo<Value>& args) {
-  Isolate* isolate = args.GetIsolate();
-  Local<Context> context = isolate->GetCurrentContext();
-  uint64_t thread_id = ThreadId(context);
-  args.GetReturnValue().Set(ZmqAgent::Inst()->stop_heap_profiling(thread_id));
+  args.GetReturnValue().Set(
+    Snapshot::StopTrackingHeapObjectsSync(GetLocalEnvInst(args.GetIsolate())));
 }
 
 static void StartHeapSampling(const FunctionCallbackInfo<Value>& args) {
@@ -140,14 +138,13 @@ static void StartHeapSampling(const FunctionCallbackInfo<Value>& args) {
     }}
   };
 
-  args.GetReturnValue().Set(ZmqAgent::Inst()->start_heap_sampling(message));
+  args.GetReturnValue().Set(
+    ZmqAgent::Inst()->start_heap_sampling_from_js(message));
 }
 
 static void EndHeapSampling(const FunctionCallbackInfo<Value>& args) {
-  Isolate* isolate = args.GetIsolate();
-  Local<Context> context = isolate->GetCurrentContext();
-  uint64_t thread_id = ThreadId(context);
-  args.GetReturnValue().Set(ZmqAgent::Inst()->stop_heap_sampling(thread_id));
+  args.GetReturnValue().Set(
+    Snapshot::StopSamplingSync(GetLocalEnvInst(args.GetIsolate())));
 }
 
 static void Start(const FunctionCallbackInfo<Value>& args) {


### PR DESCRIPTION
When using the JS API to retrieve specific assets and send them to the Console, there was some code paths where the data would be pushed to the Zmq sockets from the JS thread instead of the agent thread. This is a serious bug that could cause unexpected breakage. Refactor the code to actually avoid the issue.
Also took the opportunity to expand the ProfileCollector class to also support Heap Snapshots and use it in the agent.