### PR TITLE
agents: fix otlp endpoint calculation

### DIFF
--- a/agents/otlp/src/otlp_agent.cc
+++ b/agents/otlp/src/otlp_agent.cc
@@ -537,14 +537,15 @@ void OTLPAgent::config_otlp_endpoint(const json& config) {
     is_http = *it == "http";
   }
 
-  const std::string url = config["url"].get<std::string>() + "/v1/traces";
+  const std::string url = config["url"].get<std::string>();
+  const std::string trace_url = url + "/v1/traces";
   if (is_http) {
     exporter::otlp::OtlpHttpExporterOptions opts;
-    opts.url = url;
+    opts.url = trace_url;
     setup_trace_otlp_exporter(opts);
   } else {
     exporter::otlp::OtlpGrpcExporterOptions opts;
-    opts.endpoint = url;
+    opts.endpoint = trace_url;
     setup_trace_grpc_otlp_exporter(opts);
   }
 

--- a/test/agents/test-otlp-metrics.mjs
+++ b/test/agents/test-otlp-metrics.mjs
@@ -615,7 +615,7 @@ if (process.argv[2] === 'child') {
         NSOLID_INTERVAL: 1000,
         NSOLID_OTLP: 'otlp',
         OTEL_EXPORTER_OTLP_PROTOCOL: 'http/protobuf',
-        OTEL_EXPORTER_OTLP_ENDPOINT: `http://localhost:${port}/v1/metrics`,
+        OTEL_EXPORTER_OTLP_ENDPOINT: `http://localhost:${port}`,
       };
     },
     (port) => {

--- a/test/agents/test-otlp-traces.mjs
+++ b/test/agents/test-otlp-traces.mjs
@@ -280,7 +280,7 @@ if (process.argv[2] === 'child') {
         NSOLID_TRACING_ENABLED: 1,
         NSOLID_OTLP: 'otlp',
         OTEL_EXPORTER_OTLP_PROTOCOL: 'http/protobuf',
-        OTEL_EXPORTER_OTLP_ENDPOINT: `http://localhost:${port}/v1/traces`,
+        OTEL_EXPORTER_OTLP_ENDPOINT: `http://localhost:${port}`,
       };
     },
     (port) => {

--- a/test/common/nsolid-otlp-agent/index.js
+++ b/test/common/nsolid-otlp-agent/index.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const assert = require('node:assert');
 const { EventEmitter } = require('node:events');
 const { fork } = require('node:child_process');
 const path = require('node:path');
@@ -31,7 +32,8 @@ class OTLPServer extends EventEmitter {
           break;
       }
     });
-    this.#server.on('exit', (code, signal) => {
+    this.#server.on('exit', (code) => {
+      assert.strictEqual(code, 0);
       this.#server = null;
     });
   }

--- a/test/common/nsolid-otlp-agent/otlp-server.mjs
+++ b/test/common/nsolid-otlp-agent/otlp-server.mjs
@@ -23,20 +23,20 @@ async function startServer(cb) {
         data: 'Hello World!',
       }));
 
-      // If url ends in traces, decode spans
-      if (req.url.endsWith('/v1/traces')) {
+      // If url ends in traces, decode spans.
+      console.log(req.url);
+      assert.ok(req.url === '/v1/traces' || req.url === '/v1/metrics');
+      if (req.url === '/v1/traces') {
         const data = ExportSpansServiceRequestProto.decode(Buffer.concat(body));
         const spans = data?.toJSON();
         cb(null, 'spans', spans);
         return;
       }
 
-      // If url ends in metrics, decode metrics
-      if (req.url.endsWith('/v1/metrics')) {
-        const data = ExportMetricsServiceRequestProto.decode(Buffer.concat(body));
-        const metrics = data?.toJSON();
-        cb(null, 'metrics', metrics);
-      }
+      // Otherwise decode metrics.
+      const data = ExportMetricsServiceRequestProto.decode(Buffer.concat(body));
+      const metrics = data?.toJSON();
+      cb(null, 'metrics', metrics);
     });
   });
 


### PR DESCRIPTION
The calculated endpoint could end up ending in `/v1/traces/v1/metrics` or `/v1/traces/metrics` which is obviously wrong. Fix the corresponding tests so they actually catch the error.

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
