### PR TITLE
Multiple changes/fixes in preparation for gRPC

### DIFF
--- a/agents/otlp/src/otlp_common.cc
+++ b/agents/otlp/src/otlp_common.cc
@@ -181,7 +181,8 @@ Resource* UpdateResource(ResourceAttributes&& attrs) {
 // NOLINTNEXTLINE(runtime/references)
 void fill_proc_metrics(std::vector<MetricData>& metrics,
                        const ProcessMetrics::MetricsStor& stor,
-                       const ProcessMetrics::MetricsStor& prev_stor) {
+                       const ProcessMetrics::MetricsStor& prev_stor,
+                       bool use_snake_case) {
   time_point end{
         duration_cast<time_point::duration>(
           milliseconds(static_cast<uint64_t>(stor.timestamp)))};
@@ -213,7 +214,7 @@ void fill_proc_metrics(std::vector<MetricData>& metrics,
         add_counter(metrics,                                                   \
                     process_start,                                             \
                     end,                                                       \
-                    #CName,                                                    \
+                    use_snake_case ? #CName : #JSName,                         \
                     Unit,                                                      \
                     type,                                                      \
                     value);                                                    \
@@ -221,7 +222,13 @@ void fill_proc_metrics(std::vector<MetricData>& metrics,
       break;                                                                   \
       case MetricsType::EGauge:                                                \
       {                                                                        \
-        add_gauge(metrics, process_start, end, #CName, Unit, type, value);     \
+        add_gauge(metrics,                                                     \
+                  process_start,                                               \
+                  end,                                                         \
+                  use_snake_case ? #CName : #JSName,                           \
+                  Unit,                                                        \
+                  type,                                                        \
+                  value);                                                      \
       }                                                                        \
       break;                                                                   \
       default:                                                                 \
@@ -247,7 +254,8 @@ NSOLID_PROCESS_METRICS_DOUBLE(V)
 
 // NOLINTNEXTLINE(runtime/references)
 void fill_env_metrics(std::vector<MetricData>& metrics,
-                      const ThreadMetrics::MetricsStor& stor) {
+                      const ThreadMetrics::MetricsStor& stor,
+                      bool use_snake_case) {
   time_point end{
         duration_cast<time_point::duration>(
           milliseconds(static_cast<uint64_t>(stor.timestamp)))};
@@ -284,7 +292,7 @@ void fill_env_metrics(std::vector<MetricData>& metrics,
         add_counter(metrics,                                                   \
                     process_start,                                             \
                     end,                                                       \
-                    #CName,                                                    \
+                    use_snake_case ? #CName : #JSName,                         \
                     Unit,                                                      \
                     type,                                                      \
                     value,                                                     \
@@ -296,7 +304,7 @@ void fill_env_metrics(std::vector<MetricData>& metrics,
         add_gauge(metrics,                                                     \
                   process_start,                                               \
                   end,                                                         \
-                  #CName,                                                      \
+                  use_snake_case ? #CName : #JSName,                           \
                   Unit,                                                        \
                   type,                                                        \
                   value,                                                       \
@@ -314,7 +322,7 @@ NSOLID_ENV_METRICS_NUMBERS(V)
   add_summary(metrics,
               process_start,
               end,
-              "gc_dur",
+              use_snake_case ? "gc_dur_us" : "gcDurUs",
               kNSUSecs,
               InstrumentValueType::kDouble,
               {{ 0.5, stor.gc_dur_us_median },
@@ -331,7 +339,7 @@ NSOLID_ENV_METRICS_NUMBERS(V)
   add_summary(metrics,
               process_start,
               end,
-              "http_client",
+              use_snake_case ? "http_client" : "httpClient",
               kNSMSecs,
               InstrumentValueType::kDouble,
               {{ 0.5, stor.http_client99_ptile },
@@ -340,7 +348,7 @@ NSOLID_ENV_METRICS_NUMBERS(V)
   add_summary(metrics,
               process_start,
               end,
-              "http_server",
+              use_snake_case ? "http_server" : "httpServer",
               kNSMSecs,
               InstrumentValueType::kDouble,
               {{ 0.5, stor.http_server_median },

--- a/agents/otlp/src/otlp_common.cc
+++ b/agents/otlp/src/otlp_common.cc
@@ -412,6 +412,7 @@ void fill_recordable(Recordable* recordable, const Tracer::SpanStor& s) {
   }
 
   recordable->SetAttribute("thread.id", s.thread_id);
+  recordable->SetAttribute("nsolid.span_type", s.type);
 
   recordable->SetResource(*GetResource());
 }

--- a/agents/otlp/src/otlp_common.h
+++ b/agents/otlp/src/otlp_common.h
@@ -49,10 +49,12 @@ OPENTELEMETRY_NAMESPACE::sdk::resource::Resource* UpdateResource(
 
 void fill_proc_metrics(std::vector<opentelemetry::sdk::metrics::MetricData>&,
                        const ProcessMetrics::MetricsStor& stor,
-                       const ProcessMetrics::MetricsStor& prev_stor);
+                       const ProcessMetrics::MetricsStor& prev_stor,
+                       bool use_snake_case = true);
 
 void fill_env_metrics(std::vector<opentelemetry::sdk::metrics::MetricData>&,
-                      const ThreadMetrics::MetricsStor& stor);
+                      const ThreadMetrics::MetricsStor& stor,
+                      bool use_snake_case = true);
 
 void fill_log_recordable(OPENTELEMETRY_NAMESPACE::sdk::logs::Recordable*,
                          const LogWriteInfo&);

--- a/agents/otlp/src/otlp_common.h
+++ b/agents/otlp/src/otlp_common.h
@@ -48,7 +48,8 @@ OPENTELEMETRY_NAMESPACE::sdk::resource::Resource* UpdateResource(
     OPENTELEMETRY_NAMESPACE::sdk::resource::ResourceAttributes&&);
 
 void fill_proc_metrics(std::vector<opentelemetry::sdk::metrics::MetricData>&,
-                       const ProcessMetrics::MetricsStor& stor);
+                       const ProcessMetrics::MetricsStor& stor,
+                       const ProcessMetrics::MetricsStor& prev_stor);
 
 void fill_env_metrics(std::vector<opentelemetry::sdk::metrics::MetricData>&,
                       const ThreadMetrics::MetricsStor& stor);

--- a/doc/changelogs/NSOLID_CHANGELOG_V5_NODE_V20.md
+++ b/doc/changelogs/NSOLID_CHANGELOG_V5_NODE_V20.md
@@ -26,7 +26,6 @@
 * \[[`3913f0e27f`](https://github.com/nodesource/nsolid/commit/3913f0e27f)] - **agents:** refactor ZmqAgent to use ProfileCollector (Santiago Gimeno) [nodesource/nsolid#161](https://github.com/nodesource/nsolid/pull/161)
 * \[[`183b115e48`](https://github.com/nodesource/nsolid/commit/183b115e48)] - **agents:** implement ProfileCollector class (Santiago Gimeno) [nodesource/nsolid#161](https://github.com/nodesource/nsolid/pull/161)
 
-
 ## 2024-08-23, Version 20.17.0-nsolid-v5.3.3 'Iron'
 
 ### Commits

--- a/test/agents/test-otlp-grpc-metrics.mjs
+++ b/test/agents/test-otlp-grpc-metrics.mjs
@@ -122,7 +122,7 @@ if (process.argv[2] === 'child') {
     ['loop_avg_tasks', undefined, 'asDouble', 'gauge'],
     ['loop_estimated_lag', 'ms', 'asDouble', 'gauge'],
     ['loop_idle_percent', undefined, 'asDouble', 'gauge'],
-    ['gc_dur', 'us', 'asDouble', 'summary'],
+    ['gc_dur_us', 'us', 'asDouble', 'summary'],
     ['dns', 'ms', 'asDouble', 'summary'],
     ['http_client', 'ms', 'asDouble', 'summary'],
     ['http_server', 'ms', 'asDouble', 'summary'],

--- a/test/agents/test-otlp-grpc-traces.mjs
+++ b/test/agents/test-otlp-grpc-traces.mjs
@@ -160,7 +160,7 @@ if (process.argv[2] === 'child') {
     const endTimeUnixNano = BigInt(serverSpan.endTimeUnixNano);
     assert.ok(endTimeUnixNano);
     validateArray(serverSpan.attributes, 'serverSpan.attributes');
-    assert.strictEqual(serverSpan.attributes.length, 5);
+    assert.strictEqual(serverSpan.attributes.length, 6);
     assert.strictEqual(serverSpan.attributes[0].key, 'http.method');
     assert.strictEqual(serverSpan.attributes[0].value.stringValue, 'GET');
     assert.strictEqual(serverSpan.attributes[1].key, 'http.status_code');
@@ -172,6 +172,8 @@ if (process.argv[2] === 'child') {
                        `http://127.0.0.1:${port}/`);
     assert.strictEqual(serverSpan.attributes[4].key, 'thread.id');
     assert.strictEqual(serverSpan.attributes[4].value.intValue, `${threadId}`);
+    assert.strictEqual(serverSpan.attributes[5].key, 'nsolid.span_type');
+    assert.strictEqual(serverSpan.attributes[5].value.intValue, '8');
 
     const clientSpan = spans[1];
     validateId(serverSpan.traceId, 16);
@@ -183,7 +185,7 @@ if (process.argv[2] === 'child') {
     const endTimeUnixNano2 = BigInt(clientSpan.endTimeUnixNano);
     assert.ok(endTimeUnixNano2);
     validateArray(clientSpan.attributes, 'clientSpan.attributes');
-    assert.strictEqual(clientSpan.attributes.length, 5);
+    assert.strictEqual(clientSpan.attributes.length, 6);
     assert.strictEqual(clientSpan.attributes[0].key, 'http.method');
     assert.strictEqual(clientSpan.attributes[0].value.stringValue, 'GET');
     assert.strictEqual(clientSpan.attributes[1].key, 'http.status_code');
@@ -195,6 +197,8 @@ if (process.argv[2] === 'child') {
                        `http://127.0.0.1:${port}/`);
     assert.strictEqual(clientSpan.attributes[4].key, 'thread.id');
     assert.strictEqual(clientSpan.attributes[4].value.intValue, `${threadId}`);
+    assert.strictEqual(clientSpan.attributes[5].key, 'nsolid.span_type');
+    assert.strictEqual(clientSpan.attributes[5].value.intValue, '4');
   }
 
   function mergeResourceSpans(data, result) {

--- a/test/agents/test-otlp-metrics.mjs
+++ b/test/agents/test-otlp-metrics.mjs
@@ -122,7 +122,7 @@ if (process.argv[2] === 'child') {
     ['loop_avg_tasks', undefined, 'asDouble', 'gauge'],
     ['loop_estimated_lag', 'ms', 'asDouble', 'gauge'],
     ['loop_idle_percent', undefined, 'asDouble', 'gauge'],
-    ['gc_dur', 'us', 'asDouble', 'summary'],
+    ['gc_dur_us', 'us', 'asDouble', 'summary'],
     ['dns', 'ms', 'asDouble', 'summary'],
     ['http_client', 'ms', 'asDouble', 'summary'],
     ['http_server', 'ms', 'asDouble', 'summary'],

--- a/test/agents/test-otlp-traces.mjs
+++ b/test/agents/test-otlp-traces.mjs
@@ -145,7 +145,7 @@ if (process.argv[2] === 'child') {
     const endTimeUnixNano = BigInt(serverSpan.endTimeUnixNano);
     assert.ok(endTimeUnixNano);
     validateArray(serverSpan.attributes, 'serverSpan.attributes');
-    assert.strictEqual(serverSpan.attributes.length, 5);
+    assert.strictEqual(serverSpan.attributes.length, 6);
     assert.strictEqual(serverSpan.attributes[0].key, 'http.method');
     assert.strictEqual(serverSpan.attributes[0].value.stringValue, 'GET');
     assert.strictEqual(serverSpan.attributes[1].key, 'http.status_code');
@@ -157,6 +157,8 @@ if (process.argv[2] === 'child') {
                        `http://127.0.0.1:${port}/`);
     assert.strictEqual(serverSpan.attributes[4].key, 'thread.id');
     assert.strictEqual(serverSpan.attributes[4].value.intValue, `${threadId}`);
+    assert.strictEqual(serverSpan.attributes[5].key, 'nsolid.span_type');
+    assert.strictEqual(serverSpan.attributes[5].value.intValue, '8');
 
     const clientSpan = spans[1];
     validateString(clientSpan.traceId, 'clientSpan.traceId');
@@ -168,7 +170,7 @@ if (process.argv[2] === 'child') {
     const endTimeUnixNano2 = BigInt(clientSpan.endTimeUnixNano);
     assert.ok(endTimeUnixNano2);
     validateArray(clientSpan.attributes, 'clientSpan.attributes');
-    assert.strictEqual(clientSpan.attributes.length, 5);
+    assert.strictEqual(clientSpan.attributes.length, 6);
     assert.strictEqual(clientSpan.attributes[0].key, 'http.method');
     assert.strictEqual(clientSpan.attributes[0].value.stringValue, 'GET');
     assert.strictEqual(clientSpan.attributes[1].key, 'http.status_code');
@@ -180,6 +182,8 @@ if (process.argv[2] === 'child') {
                        `http://127.0.0.1:${port}/`);
     assert.strictEqual(clientSpan.attributes[4].key, 'thread.id');
     assert.strictEqual(clientSpan.attributes[4].value.intValue, `${threadId}`);
+    assert.strictEqual(clientSpan.attributes[5].key, 'nsolid.span_type');
+    assert.strictEqual(clientSpan.attributes[5].value.intValue, '4');
   }
 
   function mergeResourceSpans(data, result) {


### PR DESCRIPTION
```
agents: move text metrics calculation to common
    
The `Resource` is now updated in `fill_proc_metrics()` so there's no
need for every agent to do it.
```
```
agents: make metrics name format configure
    
So they can be either camelCase or snake_case. Out OTLPAgent uses
`snake_case`. The upcoming GRPCAgent will use `camelCase`.
Also, fix the name of the `gc_dur_us` metric.
```
```
agents: add nsolid.span_kind attribute to Spans
```
```
doc: fix linting issue
```