### PR TITLE
StartupTimes changes/fixes

### DIFF
--- a/src/nsolid.cc
+++ b/src/nsolid.cc
@@ -99,7 +99,7 @@ bool IsMainThread(SharedEnvInst envinst) {
 int GetStartupTimes(SharedEnvInst envinst_sp, std::string* times) {
   if (envinst_sp == nullptr)
     return UV_ESRCH;
-  *times = envinst_sp->GetStartupTimes();
+  *times = envinst_sp->GetStartupTimesJSON();
   return 0;
 }
 

--- a/src/nsolid/nsolid_api.cc
+++ b/src/nsolid/nsolid_api.cc
@@ -937,11 +937,13 @@ void EnvList::AddEnv(Environment* env) {
     const AliasedFloat64Array& ps = env->performance_state()->milestones;
     double val;
 #define V(name, str)                                                           \
-    val = ps[performance::NODE_PERFORMANCE_MILESTONE_##name];                  \
-    if (val > 0)                                                               \
-      envinst_sp->startup_times_.insert({                                      \
-          get_startuptime_name(str), static_cast<uint64_t>(val) });
-    NODE_PERFORMANCE_MILESTONES(V)
+    if (std::string(str) != "timeOriginTimestamp") {                           \
+      val = ps[performance::NODE_PERFORMANCE_MILESTONE_##name];                \
+      if (val > 0)                                                             \
+        envinst_sp->startup_times_.insert({                                    \
+          get_startuptime_name(str), static_cast<uint64_t>(val) });            \
+    }
+NODE_PERFORMANCE_MILESTONES(V)
 #undef V
   }
 

--- a/src/nsolid/nsolid_api.cc
+++ b/src/nsolid/nsolid_api.cc
@@ -240,7 +240,7 @@ static void AppendStartupTimeString(const std::string& name,
 }
 
 
-std::string EnvInst::GetStartupTimes() {
+std::string EnvInst::GetStartupTimesJSON() const {
   std::string mstr = "{";
   {
     ns_mutex::scoped_lock lock(startup_times_lock_);
@@ -253,6 +253,11 @@ std::string EnvInst::GetStartupTimes() {
   mstr.pop_back();
   mstr += "}";
   return mstr;
+}
+
+std::map<std::string, uint64_t> EnvInst::GetStartupTimes() const {
+  ns_mutex::scoped_lock lock(startup_times_lock_);
+  return startup_times_;
 }
 
 
@@ -752,7 +757,7 @@ int EnvInst::CustomCommandResponse(const std::string& req_id,
 }
 
 
-EnvList::EnvList(): info_(nlohmann::json::object()) {
+EnvList::EnvList(): info_(nlohmann::json()) {
   int er;
   // Create event loop and new thread to run EnvList commands.
   uv_loop_init(&thread_loop_);
@@ -2421,7 +2426,7 @@ static void GetStartupTimes(const FunctionCallbackInfo<Value>& args) {
   Isolate* isolate = args.GetIsolate();
   EnvInst* envinst = EnvInst::GetEnvLocalInst(isolate);
   CHECK_NE(envinst, nullptr);
-  std::string ms = envinst->GetStartupTimes();
+  std::string ms = envinst->GetStartupTimesJSON();
   Local<String> ms_str =
     String::NewFromUtf8(isolate,
                         ms.c_str(),

--- a/src/nsolid/nsolid_api.h
+++ b/src/nsolid/nsolid_api.h
@@ -211,7 +211,8 @@ class EnvInst {
   void PushDnsBucket(double value);
 
   std::string GetModuleInfo();
-  std::string GetStartupTimes();
+  std::string GetStartupTimesJSON() const;
+  std::map<std::string, uint64_t> GetStartupTimes() const;
 
   void GetThreadMetrics(ThreadMetrics::MetricsStor* stor);
 

--- a/test/agents/test-zmq-startup-times.mjs
+++ b/test/agents/test-zmq-startup-times.mjs
@@ -52,6 +52,7 @@ function checkStartupTimesData(data, requestId, agentId, additionalTimes = []) {
   assert.ok(data.body.loaded_environment);
   assert.ok(data.body.loop_start);
   assert.ok(data.body.timeOrigin);
+  assert.ok(!data.body.timeOriginTimestamp);
   additionalTimes.forEach((time) => assert.ok(data.body[time]));
   Object.keys(data.body).forEach((key) => {
     validateArray(data.body[key], `data.body.${key}`);

--- a/test/parallel/test-nsolid-startup-times.js
+++ b/test/parallel/test-nsolid-startup-times.js
@@ -26,4 +26,5 @@ process.on('exit', () => {
   assert(startupTimes.loop_exit[1] > 0);
   assert.strictEqual(startupTimes.loop_exit[0], 0);
   assert(startupTimes.loop_exit[1] > startupTimes.loop_start[1]);
+  assert.ok(!startupTimes.timeOriginTimestamp);
 });


### PR DESCRIPTION
```
src: change internal GetStartupTimes() signature
    
It now returns a `std::map<std::string, uint64_t>`.
The previous implementation that returns a JSON is renamed to
`GetStartupTimesJSON()` which now is used by the public API, to avoid
breakage.
```
```
src: remove timeOriginTimestamp from startupTimes
```