### PR TITLE
deps: avoid using unset values in cpu profiler

### DIFF
--- a/deps/v8/src/profiler/profile-generator.cc
+++ b/deps/v8/src/profiler/profile-generator.cc
@@ -805,14 +805,24 @@ void CpuProfileJSONSerializer::SerializeCallFrame(
     const v8::CpuProfileNode* node) {
   writer_->AddString("\"functionName\":");
   writer_->EscapeAndAddString(node->GetFunctionNameStr());
-  writer_->AddString(",\"lineNumber\":");
-  writer_->AddNumber(node->GetLineNumber() - 1);
-  writer_->AddString(",\"columnNumber\":");
-  writer_->AddNumber(node->GetColumnNumber() - 1);
+  if (node->GetLineNumber()) {
+    writer_->AddString(",\"lineNumber\":");
+    writer_->AddNumber(node->GetLineNumber() - 1);
+  }
+
+  if (node->GetColumnNumber()) {
+    writer_->AddString(",\"columnNumber\":");
+    writer_->AddNumber(node->GetColumnNumber() - 1);
+  }
+
   writer_->AddString(",\"scriptId\":");
   writer_->AddNumber(node->GetScriptId());
-  writer_->AddString(",\"url\":");
-  writer_->EscapeAndAddString(node->GetScriptResourceNameStr());
+
+  const char* url = node->GetScriptResourceNameStr();
+  if (url) {
+    writer_->AddString(",\"url\":");
+    writer_->EscapeAndAddString(url);
+  }
 }
 
 void CpuProfileJSONSerializer::SerializeChildren(const v8::CpuProfileNode* node,


### PR DESCRIPTION
`lineNumber`, `columnNumber` and `url` node fields can be actually undefined. Make sure we avoid integer overflows and potential crashes.

As an example, if `lineNumber` or `columnNumber` are undefined, they were taking the `4294967295` which obviously doesn't make any sense.

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
