### PR TITLE
agents: fix grpc keepalive configuration

### DIFF
--- a/agents/grpc/src/grpc_client.cc
+++ b/agents/grpc/src/grpc_client.cc
@@ -51,11 +51,14 @@ std::shared_ptr<Channel>
   std::shared_ptr<Channel> channel;
   ChannelArguments grpc_arguments;
   // Configure the keepalive of the Client Channel. The keepalive time period is
-  // set to 20 seconds, with a timeout of 10 seconds. Additionally, pings will
-  // be sent even if there are no calls in flight on an active connection.
-  grpc_arguments.SetInt(GRPC_ARG_KEEPALIVE_TIME_MS, 20 * 1000 /*20 sec*/);
-  grpc_arguments.SetInt(GRPC_ARG_KEEPALIVE_TIMEOUT_MS, 10 * 1000 /*10 sec*/);
+  // set to 30 seconds, with a timeout of 15 seconds. Additionally, pings will
+  // be sent even if there are no calls nor headers/data in flight on an active
+  // connection. Important: these settings should match the ones configured
+  // server-side.
+  grpc_arguments.SetInt(GRPC_ARG_KEEPALIVE_TIME_MS, 30 * 1000 /* 30 sec*/);
+  grpc_arguments.SetInt(GRPC_ARG_KEEPALIVE_TIMEOUT_MS, 15 * 1000 /* 15 sec*/);
   grpc_arguments.SetInt(GRPC_ARG_KEEPALIVE_PERMIT_WITHOUT_CALLS, 1);
+  grpc_arguments.SetInt(GRPC_ARG_HTTP2_MAX_PINGS_WITHOUT_DATA, 0);
   if (!options.use_ssl_credentials) {
     channel = CreateCustomChannel(options.endpoint,
                                   InsecureChannelCredentials(),


### PR DESCRIPTION
Increase a bit the keepalive period and timeout.
Also, set `GRPC_ARG_HTTP2_MAX_PINGS_WITHOUT_DATA` to `0` to make sure we can send `PING` frames indefinitelly even if there's no activity in the channel, to make sure the channel is up for as long as possible.

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
