### PR TITLE
agents: fix possible grpc mutex race condition

### DIFF
--- a/agents/grpc/src/grpc_agent.cc
+++ b/agents/grpc/src/grpc_agent.cc
@@ -1036,7 +1036,6 @@ int GrpcAgent::config(const json& config) {
       Debug("GrpcAgent configured. Endpoint: %s. Insecure: %d\n",
             endpoint.c_str(), static_cast<unsigned>(insecure));
 
-
       OtlpGrpcClientOptions opts;
       opts.endpoint = endpoint;
       opts.metadata = {{"nsolid-agent-id", agent_id_},
@@ -1050,9 +1049,13 @@ int GrpcAgent::config(const json& config) {
         }
       }
 
+      nsolid_service_stub_ = GrpcClient::MakeNSolidServiceStub(opts);
+      // CommandStream needs to be created before the OTLP client to avoid
+      // a race condition with abseil mutexes.
+      reset_command_stream();
+
       std::shared_ptr<OtlpGrpcClient> client =
           OtlpGrpcClientFactory::Create(opts);
-      nsolid_service_stub_ = GrpcClient::MakeNSolidServiceStub(opts);
 
       {
         OtlpGrpcExporterOptions options;
@@ -1104,8 +1107,6 @@ int GrpcAgent::config(const json& config) {
         log_exporter_ =
           std::make_unique<OtlpGrpcLogRecordExporter>(options, client);
       }
-
-      reset_command_stream();
     }
   }
 

--- a/test/addons/nsolid-statsdagent/binding.gyp
+++ b/test/addons/nsolid-statsdagent/binding.gyp
@@ -20,7 +20,7 @@
     'configurations': {
       'Debug': {
         'defines': [ 'DEBUG', '_DEBUG' ],
-        'cflags_cc': [ '-std=c++20', '-g', '-O0', '-fstandalone-debug' ],
+        'cflags_cc': [ '-std=c++20', '-g', '-O0' ],
       },
       'Release': {
         'cflags_cc': [ '-std=c++20' ],


### PR DESCRIPTION
As reported by abseil-cpp. By the looks of it, it's fixed if we make
sure `CommandStream` instnace is created before the `OtlpGrpcClient`
instance.

Also:
```
test: fix nsolid-statsdagent test debug build
```

Fixes: https://github.com/nodesource/nsolid-roadmap/issues/28