### PR TITLE
src: add fast api calls to push span strings

### DIFF
--- a/lib/_http_client.js
+++ b/lib/_http_client.js
@@ -481,10 +481,9 @@ function ClientRequest(input, options, cb) {
     api.context.with(api.trace.setSpan(api.context.active(), span), () => {
       fn.call(this);
       // At this point we know the request is actually being initiated
-      const u = `${protocol}//${this.getHeader('host')}${this.path}`;
       span._pushSpanDataString(kSpanHttpMethod, method);
       span._pushSpanDataString(kSpanHttpProtocolVersion, '1.1');
-      span._pushSpanDataString(kSpanHttpReqUrl, u);
+      span._pushSpanDataString3(kSpanHttpReqUrl, protocol, this.getHeader('host') || 'localhost', this.path);
       this.prependOnceListener('error', requestOnError);
       this.once('close', requestOnClose);
     }, this);

--- a/lib/_http_server.js
+++ b/lib/_http_server.js
@@ -1113,8 +1113,7 @@ function parserOnIncoming(server, socket, state, req, keepAlive) {
   let api;
   let span;
   if (generateSpan(kSpanHttpServer)) {
-    const protocol = req.connection.encrypted ? 'https' : 'http';
-    const u = `${protocol}://${req.headers.host || 'localhost'}${req.originalUrl || req.url}`;
+    const protocol = req.connection.encrypted ? 'https:' : 'http:';
     api = getApi();
     const tracer = api.trace.getTracer('http');
     const ctxt = extractSpanContextFromHttpHeaders(api.ROOT_CONTEXT,
@@ -1128,7 +1127,7 @@ function parserOnIncoming(server, socket, state, req, keepAlive) {
     req[nsolid_span_id_s] = span;
     span._pushSpanDataString(kSpanHttpMethod, req.method);
     span._pushSpanDataString(kSpanHttpProtocolVersion, req.httpVersion);
-    span._pushSpanDataString(kSpanHttpReqUrl, u);
+    span._pushSpanDataString3(kSpanHttpReqUrl, protocol, req.headers.host || 'localhost', req.originalUrl || req.url);
   }
 
   if (req.upgrade) {

--- a/lib/internal/otel/trace.js
+++ b/lib/internal/otel/trace.js
@@ -8,7 +8,6 @@ const {
 const binding = internalBinding('nsolid_api');
 const { getSpanId,
         getTraceId,
-        pushSpanDataString,
         nsolid_consts } = binding;
 
 const {
@@ -38,7 +37,7 @@ class SpanContext {
   }
 }
 
-function Span(internalId, ids_str, spanContext, startTime, type, kind, links) {
+function Span(internalId, parentSpanId, spanContext, startTime, type, kind, links) {
   this._spanContext = spanContext;
   this.ended = false;
   this.internalId = internalId;
@@ -56,7 +55,11 @@ function Span(internalId, ids_str, spanContext, startTime, type, kind, links) {
       this._pushSpanDataUint64(nsolid_consts.kSpanKind, this.kind);
     }
 
-    this._pushSpanDataString(nsolid_consts.kSpanOtelIds, ids_str);
+    this._pushSpanDataString(nsolid_consts.kSpanTraceId, spanContext.traceId);
+    this._pushSpanDataString(nsolid_consts.kSpanSpanId, spanContext.spanId);
+    if (parentSpanId) {
+      this._pushSpanDataString(nsolid_consts.kSpanParentSpanId, parentSpanId);
+    }
   }
 }
 
@@ -210,7 +213,15 @@ Span.prototype._pushSpanDataDouble = function(type, name) {
 
 Span.prototype._pushSpanDataString = function(type, name) {
   if (this._isSampled()) {
-    pushSpanDataString(this.internalId, type, name);
+    binding.pushSpanDataString(this.internalId, type, name);
+  }
+
+  return this;
+};
+
+Span.prototype._pushSpanDataString3 = function(type, val1, val2, val3) {
+  if (this._isSampled()) {
+    binding.pushSpanDataString3(this.internalId, type, val1, val2, val3);
   }
 
   return this;
@@ -240,7 +251,6 @@ class Tracer {
       }
     }
 
-    let ids_str;
     let traceState;
     let traceId;
 
@@ -248,12 +258,10 @@ class Tracer {
     if (!parentContext) {
       // New root span.
       traceId = getTraceId();
-      ids_str = `${traceId}:${spanId}`;
     } else {
       // New child span.
       traceId = parentContext.traceId;
       traceState = parentContext.traceState;
-      ids_str = `${traceId}:${spanId}:${parentContext.spanId}`;
     }
 
     const internalId = newInternalSpanId();
@@ -269,7 +277,7 @@ class Tracer {
 
     const startTime = options.startTime || now();
     const span = new Span(internalId,
-                          ids_str,
+                          parentContext?.spanId,
                           spanContext,
                           startTime,
                           options.type || nsolid_consts.kSpanCustom,

--- a/src/node_external_reference.h
+++ b/src/node_external_reference.h
@@ -94,6 +94,19 @@ using CFunctionBufferCopy =
                  uint32_t source_start,
                  uint32_t to_copy);
 
+using CFunctionPushSpanDataString =
+    void (*)(v8::Local<v8::Object> receiver,
+             uint32_t trace_id,
+             uint32_t type,
+             const v8::FastOneByteString& val);
+using CFunctionPushSpanDataString3 =
+    void (*)(v8::Local<v8::Object> receiver,
+             uint32_t trace_id,
+             uint32_t type,
+             const v8::FastOneByteString& val1,
+             const v8::FastOneByteString& val2,
+             const v8::FastOneByteString& val3);
+
 // This class manages the external references from the V8 heap
 // to the C++ addresses in Node.js.
 class ExternalReferenceRegistry {
@@ -125,6 +138,8 @@ class ExternalReferenceRegistry {
   V(CFunctionWithBool)                                                         \
   V(CFunctionBufferCopy)                                                       \
   V(CFunctionWriteString)                                                      \
+  V(CFunctionPushSpanDataString)                                               \
+  V(CFunctionPushSpanDataString3)                                              \
   V(const v8::CFunctionInfo*)                                                  \
   V(v8::FunctionCallback)                                                      \
   V(v8::AccessorNameGetterCallback)                                            \

--- a/src/nsolid/nsolid_api.cc
+++ b/src/nsolid/nsolid_api.cc
@@ -41,11 +41,11 @@ using nsuv::ns_timer;
 
 using tracing::Span;
 using tracing::SpanItem;
-using tracing::SpanPropBase;
 
 using v8::ArrayBuffer;
 using v8::BackingStore;
 using v8::Context;
+using v8::FastOneByteString;
 using v8::Float64Array;
 using v8::Function;
 using v8::FunctionCallbackInfo;
@@ -2364,34 +2364,94 @@ void BindingData::PushSpanDataUint64Impl(BindingData* data,
       SpanItem{ trace_id, envinst->thread_id(), std::move(prop) });
 }
 
-
-static void PushSpanDataString(const FunctionCallbackInfo<Value>& args) {
+void BindingData::SlowPushSpanDataString(
+    const FunctionCallbackInfo<Value>& args) {
   Isolate* isolate = args.GetIsolate();
-  EnvInst* envinst = EnvInst::GetEnvLocalInst(isolate);
-  DCHECK_NE(envinst, nullptr);
   DCHECK_EQ(args.Length(), 3);
   DCHECK(args[0]->IsUint32());
   DCHECK(args[1]->IsUint32());
   DCHECK(args[2]->IsString());
   uint32_t trace_id = args[0].As<Uint32>()->Value();
-  Span::PropType prop_type =
-    static_cast<Span::PropType>(args[1].As<Uint32>()->Value());
-  std::unique_ptr<SpanPropBase> prop;
+  uint32_t type = args[1].As<Uint32>()->Value();
   Local<String> value_s = args[2].As<String>();
-  if (prop_type == Span::kSpanOtelIds && value_s->IsOneByte()) {
-    char ids[67];
-    int len = value_s->WriteOneByte(isolate, reinterpret_cast<uint8_t*>(ids));
-    ids[len] = '\0';
-    prop = Span::createSpanProp<std::string>(prop_type, ids);
-  } else {
-    String::Utf8Value value_str(isolate, value_s);
-    prop = Span::createSpanProp<std::string>(prop_type, *value_str);
-  }
+  BindingData* data = FromJSObject<BindingData>(args.This());
+  const std::string val = *String::Utf8Value(isolate, value_s);
+  PushSpanDataStringImpl(data, trace_id, type, val);
+}
 
-  SpanItem item = { trace_id,
-                    envinst->thread_id(),
-                    std::move(prop) };
-  EnvList::Inst()->GetTracer()->pushSpanData(std::move(item));
+
+void BindingData::FastPushSpanDataString(v8::Local<v8::Object> receiver,
+                                         uint32_t trace_id,
+                                         uint32_t type,
+                                         const FastOneByteString& val) {
+  PushSpanDataStringImpl(FromJSObject<BindingData>(receiver),
+                         trace_id,
+                         type,
+                         std::string(val.data, val.length));
+}
+
+
+void BindingData::PushSpanDataStringImpl(BindingData* data,
+                                         uint32_t trace_id,
+                                         uint32_t type,
+                                         const std::string& val) {
+  Span::PropType prop_type = static_cast<Span::PropType>(type);
+  auto prop = Span::createSpanProp<std::string>(prop_type, val);
+  EnvInst* envinst = data->env()->envinst_.get();
+  EnvList::Inst()->GetTracer()->pushSpanData(
+      SpanItem{ trace_id, envinst->thread_id(), std::move(prop) });
+}
+
+
+void BindingData::SlowPushSpanDataString3(
+    const FunctionCallbackInfo<Value>& args) {
+  Isolate* isolate = args.GetIsolate();
+  DCHECK_EQ(args.Length(), 5);
+  DCHECK(args[0]->IsUint32());
+  DCHECK(args[1]->IsUint32());
+  DCHECK(args[2]->IsString());
+  DCHECK(args[3]->IsString());
+  DCHECK(args[4]->IsString());
+  uint32_t trace_id = args[0].As<Uint32>()->Value();
+  uint32_t type = args[1].As<Uint32>()->Value();
+  Local<String> value_s1 = args[2].As<String>();
+  Local<String> value_s2 = args[3].As<String>();
+  Local<String> value_s3 = args[4].As<String>();
+  BindingData* data = FromJSObject<BindingData>(args.This());
+  const std::string val1 = *String::Utf8Value(isolate, value_s1);
+  const std::string val2 = *String::Utf8Value(isolate, value_s2);
+  const std::string val3 = *String::Utf8Value(isolate, value_s3);
+  PushSpanDataStringImpl3(data, trace_id, type, val1, val2, val3);
+}
+
+
+void BindingData::FastPushSpanDataString3(v8::Local<v8::Object> receiver,
+                                          uint32_t trace_id,
+                                          uint32_t type,
+                                          const FastOneByteString& val1,
+                                          const FastOneByteString& val2,
+                                          const FastOneByteString& val3) {
+  PushSpanDataStringImpl3(FromJSObject<BindingData>(receiver),
+                         trace_id,
+                         type,
+                         std::string(val1.data, val1.length),
+                         std::string(val2.data, val2.length),
+                         std::string(val3.data, val3.length));
+}
+
+void BindingData::PushSpanDataStringImpl3(BindingData* data,
+                                          uint32_t trace_id,
+                                          uint32_t type,
+                                          const std::string& val1,
+                                          const std::string& val2,
+                                          const std::string& val3) {
+  Span::PropType prop_type = static_cast<Span::PropType>(type);
+  ASSERT_EQ(prop_type, Span::kSpanHttpReqUrl);
+  auto prop =
+      Span::createSpanProp<std::string>(prop_type, val1 + "//" + val2 + val3);
+  EnvInst* envinst = data->env()->envinst_.get();
+  EnvList::Inst()->GetTracer()->pushSpanData(
+      SpanItem{ trace_id, envinst->thread_id(), std::move(prop) });
 }
 
 
@@ -3041,6 +3101,10 @@ v8::CFunction BindingData::fast_push_span_data_double_(
     v8::CFunction::Make(FastPushSpanDataDouble));
 v8::CFunction BindingData::fast_push_span_data_uint64_(
     v8::CFunction::Make(FastPushSpanDataUint64));
+v8::CFunction BindingData::fast_push_span_data_string_(
+    v8::CFunction::Make(FastPushSpanDataString));
+v8::CFunction BindingData::fast_push_span_data_string3_(
+    v8::CFunction::Make(FastPushSpanDataString3));
 
 
 void BindingData::Initialize(Local<Object> target,
@@ -3080,10 +3144,19 @@ void BindingData::Initialize(Local<Object> target,
                 "pushSpanDataUint64",
                 SlowPushSpanDataUint64,
                 &fast_push_span_data_uint64_);
+  SetFastMethod(context,
+                target,
+                "pushSpanDataString",
+                SlowPushSpanDataString,
+                &fast_push_span_data_string_);
+  SetFastMethod(context,
+                target,
+                "pushSpanDataString3",
+                SlowPushSpanDataString3,
+                &fast_push_span_data_string3_);
 
   SetMethod(context, target, "agentId", AgentId);
   SetMethod(context, target, "writeLog", WriteLog);
-  SetMethod(context, target, "pushSpanDataString", PushSpanDataString);
   SetMethod(context, target, "getEnvMetrics", GetEnvMetrics);
   SetMethod(context, target, "getProcessMetrics", GetProcessMetrics);
   SetMethod(context, target, "getProcessInfo", GetProcessInfo);
@@ -3214,9 +3287,16 @@ void BindingData::RegisterExternalReferences(
   registry->Register(FastPushSpanDataUint64);
   registry->Register(fast_push_span_data_uint64_.GetTypeInfo());
 
+  registry->Register(SlowPushSpanDataString);
+  registry->Register(FastPushSpanDataString);
+  registry->Register(fast_push_span_data_string_.GetTypeInfo());
+
+  registry->Register(SlowPushSpanDataString3);
+  registry->Register(FastPushSpanDataString3);
+  registry->Register(fast_push_span_data_string3_.GetTypeInfo());
+
   registry->Register(AgentId);
   registry->Register(WriteLog);
-  registry->Register(PushSpanDataString);
   registry->Register(GetEnvMetrics);
   registry->Register(GetProcessMetrics);
   registry->Register(GetProcessInfo);

--- a/src/nsolid/nsolid_bindings.h
+++ b/src/nsolid/nsolid_bindings.h
@@ -4,6 +4,7 @@
 #if defined(NODE_WANT_INTERNALS) && NODE_WANT_INTERNALS
 
 #include "node_snapshotable.h"
+#include "v8-fast-api-calls.h"
 
 namespace node {
 namespace nsolid {
@@ -58,6 +59,31 @@ class BindingData : public SnapshotableObject {
                                      uint32_t type,
                                      uint64_t val);
 
+  static void SlowPushSpanDataString(
+      const v8::FunctionCallbackInfo<v8::Value>& args);
+  static void FastPushSpanDataString(v8::Local<v8::Object> receiver,
+                                     uint32_t trace_id,
+                                     uint32_t type,
+                                     const v8::FastOneByteString& val);
+  static void PushSpanDataStringImpl(BindingData* data,
+                                     uint32_t trace_id,
+                                     uint32_t type,
+                                     const std::string& val);
+  static void SlowPushSpanDataString3(
+      const v8::FunctionCallbackInfo<v8::Value>& args);
+  static void FastPushSpanDataString3(v8::Local<v8::Object> receiver,
+                                      uint32_t trace_id,
+                                      uint32_t type,
+                                      const v8::FastOneByteString& val1,
+                                      const v8::FastOneByteString& val2,
+                                      const v8::FastOneByteString& val3);
+  static void PushSpanDataStringImpl3(BindingData* data,
+                                     uint32_t trace_id,
+                                     uint32_t type,
+                                     const std::string& val1,
+                                     const std::string& val2,
+                                     const std::string& val3);
+
   static void Initialize(v8::Local<v8::Object> target,
                          v8::Local<v8::Value> unused,
                          v8::Local<v8::Context> context,
@@ -71,6 +97,8 @@ class BindingData : public SnapshotableObject {
   static v8::CFunction fast_push_server_bucket_;
   static v8::CFunction fast_push_span_data_double_;
   static v8::CFunction fast_push_span_data_uint64_;
+  static v8::CFunction fast_push_span_data_string_;
+  static v8::CFunction fast_push_span_data_string3_;
 };
 
 }  // namespace nsolid

--- a/src/nsolid/nsolid_trace.cc
+++ b/src/nsolid/nsolid_trace.cc
@@ -49,16 +49,19 @@ void Span::add_prop(const SpanPropBase& prop) {
       stor_.start = performance_process_start_timestamp + prop.val<double>();
     }
     break;
-    case Span::kSpanOtelIds:
+    case Span::kSpanTraceId:
     {
-      auto res = utils::split(prop.val<std::string>(), ':', 3);
-      size_t size = res.size();
-      DCHECK(size == 2 || size == 3);
-      stor_.trace_id = res[0];
-      stor_.span_id = res[1];
-      if (size == 3) {
-        stor_.parent_id = res[2];
-      }
+      stor_.trace_id = prop.val<std::string>();
+    }
+    break;
+    case Span::kSpanSpanId:
+    {
+      stor_.span_id = prop.val<std::string>();
+    }
+    break;
+    case Span::kSpanParentSpanId:
+    {
+      stor_.parent_id = prop.val<std::string>();
     }
     break;
     case Span::kSpanEnd:

--- a/src/nsolid/nsolid_trace.h
+++ b/src/nsolid/nsolid_trace.h
@@ -29,10 +29,11 @@ namespace tracing {
 #define NSOLID_SPAN_PROP_TYPES_STRINGS(V)                                      \
   V(kSpanCustomAttrs)                                                          \
   V(kSpanEvent)                                                                \
-  V(kSpanOtelIds)                                                              \
   V(kSpanName)                                                                 \
-  V(kSpanStatusMsg)
-
+  V(kSpanParentSpanId)                                                         \
+  V(kSpanSpanId)                                                               \
+  V(kSpanStatusMsg)                                                            \
+  V(kSpanTraceId)
 #define NSOLID_SPAN_PROP_TYPES_NUMBERS(V)                                      \
   V(kSpanStart)                                                                \
   V(kSpanEnd)                                                                  \


### PR DESCRIPTION
This commit introduces performance optimizations for tracing span attribute handling by adding two new fast API calls:

1. FastPushSpanDataString - Optimized version of the existing string push method
2. FastPushSpanDataString3 - New method to efficiently handle three string values in a single call

Key changes include:
- Avoided JavaScript string concatenation which produces non-flattened V8 strings that cannot trigger fast API paths
- Implemented direct passing of individual string components to C++ where concatenation can happen after the fast API boundary
- Refactored HTTP URL construction in both client and server to leverage this optimization
- Improved span context handling by storing trace ID, span ID, and parent span ID as separate attributes rather than a single concatenated string

These optimizations significantly improve performance in high load scenarios:
- Up to 3.24% higher throughput in maximum load tests
- Up to 57.75% lower latency at P99.9 under constant high rate (50k req/sec)
- Substantial improvements across all high percentile latencies (P95-P99.999)
- Most dramatic gains observed in tail latencies under sustained heavy load

```
=== Benchmark Summary ===

Benchmark Type: wrk2 (constant rate)
Old Version: ./nsolid_baseline
New Version: ./nsolid_fast_push_string
Iterations: 50
Connections: 10
Duration: 60s
Rate: 40k req/sec

+------------------+-------------+-------------+------------+-----+
| Metric           | Old Version | New Version | Difference | Sig |
+------------------+-------------+-------------+------------+-----+
| Avg Latency (ms) | 2.58        | 2.34        | N/A        |     |
| P50 Latency (ms) | 1.09        | 1.10        | +0.80%     | *** |
| P90 Latency (ms) | 2.22        | 2.20        | -0.63%     | *** |
| P99 Latency (ms) | 3.09        | 2.99        | -3.31%     | *** |
| Avg Req/Sec      | 39,992.50   | 39,992.53   | +0.00%     |     |
+------------------+-------------+-------------+------------+-----+

=== Benchmark Summary ===

Benchmark Type: wrk2 (constant rate)
Old Version: ./nsolid_baseline
New Version: ./nsolid_fast_push_string
Iterations: 50
Connections: 10
Duration: 60s
Rate: 50k req/sec

+------------------+-------------+-------------+------------+-----+
| Metric           | Old Version | New Version | Difference | Sig |
+------------------+-------------+-------------+------------+-----+
| Avg Latency (ms) | 9.92        | 5.20        | N/A        |     |
| P50 Latency (ms) | 0.95        | 0.94        | -0.54%     |     |
| P90 Latency (ms) | 2.54        | 2.35        | -7.47%     | *** |
| P99 Latency (ms) | 12.00       | 5.58        | -53.49%    | *** |
| Avg Req/Sec      | 49,990.78   | 49,990.72   | -0.00%     |     |
+------------------+-------------+-------------+------------+-----+

=== Benchmark Summary ===

Benchmark Type: wrk (maximum throughput)
Old Version: ./nsolid_baseline
New Version: ./nsolid_fast_push_string
Iterations: 50
Connections: 10
Duration: 60s
Threads: 2

+------------------+-------------+-------------+------------+-----+
| Metric           | Old Version | New Version | Difference | Sig |
+------------------+-------------+-------------+------------+-----+
| Avg Latency (ms) | 0.65        | 0.64        | N/A        |     |
| P50 Latency (ms) | 0.17        | 0.16        | -3.48%     | *** |
| P90 Latency (ms) | 0.33        | 0.32        | -2.30%     | *** |
| P99 Latency (ms) | 0.36        | 0.35        | -3.33%     | *** |
| Avg Req/Sec      | 52,398.20   | 54,094.55   | +3.24%     | *** |
+------------------+-------------+-------------+------------+-----+
```

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Improved how HTTP request URLs and tracing span data are recorded, now storing URL components separately for enhanced clarity in tracing.
  - Updated internal handling of trace and span IDs to use distinct fields rather than combined strings.
  - Streamlined and optimized span data processing for better performance and maintainability.

- **New Features**
  - Added support for handling and recording multiple string properties for spans, including trace ID, span ID, parent span ID, and status messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->