### PR TITLE
src: store kernelVersion metadata in info.proto

### DIFF
--- a/agents/grpc/proto/info.proto
+++ b/agents/grpc/proto/info.proto
@@ -20,7 +20,7 @@ message InfoBody {
   repeated string tags = 13;
   uint64 totalMem = 14;
   map<string, string> versions = 15;
-  string kernelVersion = 16;
+  uint32 kernelVersion = 16;
 }
 
 message InfoEvent {

--- a/agents/grpc/proto/info.proto
+++ b/agents/grpc/proto/info.proto
@@ -20,6 +20,7 @@ message InfoBody {
   repeated string tags = 13;
   uint64 totalMem = 14;
   map<string, string> versions = 15;
+  string kernelVersion = 16;
 }
 
 message InfoEvent {

--- a/agents/grpc/src/grpc_agent.cc
+++ b/agents/grpc/src/grpc_agent.cc
@@ -253,7 +253,7 @@ void PopulateInfoEvent(grpcagent::InfoEvent* info_event,
     }
 
     if (info.find("kernelVersion") != info.end()) {
-      body->set_kernelversion(info["kernelVersion"].get<std::string>());
+      body->set_kernelversion(info["kernelVersion"].get<uint32_t>());
     }
   }
 }

--- a/agents/grpc/src/grpc_agent.cc
+++ b/agents/grpc/src/grpc_agent.cc
@@ -251,6 +251,10 @@ void PopulateInfoEvent(grpcagent::InfoEvent* info_event,
         (*body->mutable_versions())[key] = value.get<std::string>();
       }
     }
+
+    if (info.find("kernelVersion") != info.end()) {
+      body->set_kernelversion(info["kernelVersion"].get<std::string>());
+    }
   }
 }
 

--- a/agents/grpc/src/proto/info.pb.cc
+++ b/agents/grpc/src/proto/info.pb.cc
@@ -45,6 +45,7 @@ PROTOBUF_CONSTEXPR InfoBody::InfoBody(
   , /*decltype(_impl_.main_)*/{&::_pbi::fixed_address_empty_string, ::_pbi::ConstantInitialized{}}
   , /*decltype(_impl_.nodeenv_)*/{&::_pbi::fixed_address_empty_string, ::_pbi::ConstantInitialized{}}
   , /*decltype(_impl_.platform_)*/{&::_pbi::fixed_address_empty_string, ::_pbi::ConstantInitialized{}}
+  , /*decltype(_impl_.kernelversion_)*/{&::_pbi::fixed_address_empty_string, ::_pbi::ConstantInitialized{}}
   , /*decltype(_impl_.cpucores_)*/0u
   , /*decltype(_impl_.pid_)*/0u
   , /*decltype(_impl_.processstart_)*/uint64_t{0u}
@@ -110,6 +111,7 @@ const uint32_t TableStruct_info_2eproto::offsets[] PROTOBUF_SECTION_VARIABLE(pro
   PROTOBUF_FIELD_OFFSET(::grpcagent::InfoBody, _impl_.tags_),
   PROTOBUF_FIELD_OFFSET(::grpcagent::InfoBody, _impl_.totalmem_),
   PROTOBUF_FIELD_OFFSET(::grpcagent::InfoBody, _impl_.versions_),
+  PROTOBUF_FIELD_OFFSET(::grpcagent::InfoBody, _impl_.kernelversion_),
   ~0u,  // no _has_bits_
   PROTOBUF_FIELD_OFFSET(::grpcagent::InfoEvent, _internal_metadata_),
   ~0u,  // no _extensions_
@@ -122,7 +124,7 @@ const uint32_t TableStruct_info_2eproto::offsets[] PROTOBUF_SECTION_VARIABLE(pro
 static const ::_pbi::MigrationSchema schemas[] PROTOBUF_SECTION_VARIABLE(protodesc_cold) = {
   { 0, 8, -1, sizeof(::grpcagent::InfoBody_VersionsEntry_DoNotUse)},
   { 10, -1, -1, sizeof(::grpcagent::InfoBody)},
-  { 31, -1, -1, sizeof(::grpcagent::InfoEvent)},
+  { 32, -1, -1, sizeof(::grpcagent::InfoEvent)},
 };
 
 static const ::_pb::Message* const file_default_instances[] = {
@@ -132,7 +134,7 @@ static const ::_pb::Message* const file_default_instances[] = {
 };
 
 const char descriptor_table_protodef_info_2eproto[] PROTOBUF_SECTION_VARIABLE(protodesc_cold) =
-  "\n\ninfo.proto\022\tgrpcagent\032\014common.proto\"\323\002"
+  "\n\ninfo.proto\022\tgrpcagent\032\014common.proto\"\352\002"
   "\n\010InfoBody\022\013\n\003app\030\001 \001(\t\022\014\n\004arch\030\002 \001(\t\022\020\n"
   "\010cpuCores\030\003 \001(\r\022\020\n\010cpuModel\030\004 \001(\t\022\020\n\010exe"
   "cPath\030\005 \001(\t\022\020\n\010hostname\030\006 \001(\t\022\n\n\002id\030\007 \001("
@@ -140,17 +142,18 @@ const char descriptor_table_protodef_info_2eproto[] PROTOBUF_SECTION_VARIABLE(pr
   "\n \001(\r\022\020\n\010platform\030\013 \001(\t\022\024\n\014processStart\030"
   "\014 \001(\004\022\014\n\004tags\030\r \003(\t\022\020\n\010totalMem\030\016 \001(\004\0223\n"
   "\010versions\030\017 \003(\0132!.grpcagent.InfoBody.Ver"
-  "sionsEntry\032/\n\rVersionsEntry\022\013\n\003key\030\001 \001(\t"
-  "\022\r\n\005value\030\002 \001(\t:\0028\001\"Y\n\tInfoEvent\022)\n\006comm"
-  "on\030\001 \001(\0132\031.grpcagent.CommonResponse\022!\n\004b"
-  "ody\030\002 \001(\0132\023.grpcagent.InfoBodyb\006proto3"
+  "sionsEntry\022\025\n\rkernelVersion\030\020 \001(\t\032/\n\rVer"
+  "sionsEntry\022\013\n\003key\030\001 \001(\t\022\r\n\005value\030\002 \001(\t:\002"
+  "8\001\"Y\n\tInfoEvent\022)\n\006common\030\001 \001(\0132\031.grpcag"
+  "ent.CommonResponse\022!\n\004body\030\002 \001(\0132\023.grpca"
+  "gent.InfoBodyb\006proto3"
   ;
 static const ::_pbi::DescriptorTable* const descriptor_table_info_2eproto_deps[1] = {
   &::descriptor_table_common_2eproto,
 };
 static ::_pbi::once_flag descriptor_table_info_2eproto_once;
 const ::_pbi::DescriptorTable descriptor_table_info_2eproto = {
-    false, false, 478, descriptor_table_protodef_info_2eproto,
+    false, false, 501, descriptor_table_protodef_info_2eproto,
     "info.proto",
     &descriptor_table_info_2eproto_once, descriptor_table_info_2eproto_deps, 1, 3,
     schemas, file_default_instances, TableStruct_info_2eproto::offsets,
@@ -209,6 +212,7 @@ InfoBody::InfoBody(const InfoBody& from)
     , decltype(_impl_.main_){}
     , decltype(_impl_.nodeenv_){}
     , decltype(_impl_.platform_){}
+    , decltype(_impl_.kernelversion_){}
     , decltype(_impl_.cpucores_){}
     , decltype(_impl_.pid_){}
     , decltype(_impl_.processstart_){}
@@ -289,6 +293,14 @@ InfoBody::InfoBody(const InfoBody& from)
     _this->_impl_.platform_.Set(from._internal_platform(), 
       _this->GetArenaForAllocation());
   }
+  _impl_.kernelversion_.InitDefault();
+  #ifdef PROTOBUF_FORCE_COPY_DEFAULT_STRING
+    _impl_.kernelversion_.Set("", GetArenaForAllocation());
+  #endif // PROTOBUF_FORCE_COPY_DEFAULT_STRING
+  if (!from._internal_kernelversion().empty()) {
+    _this->_impl_.kernelversion_.Set(from._internal_kernelversion(), 
+      _this->GetArenaForAllocation());
+  }
   ::memcpy(&_impl_.cpucores_, &from._impl_.cpucores_,
     static_cast<size_t>(reinterpret_cast<char*>(&_impl_.totalmem_) -
     reinterpret_cast<char*>(&_impl_.cpucores_)) + sizeof(_impl_.totalmem_));
@@ -311,6 +323,7 @@ inline void InfoBody::SharedCtor(
     , decltype(_impl_.main_){}
     , decltype(_impl_.nodeenv_){}
     , decltype(_impl_.platform_){}
+    , decltype(_impl_.kernelversion_){}
     , decltype(_impl_.cpucores_){0u}
     , decltype(_impl_.pid_){0u}
     , decltype(_impl_.processstart_){uint64_t{0u}}
@@ -353,6 +366,10 @@ inline void InfoBody::SharedCtor(
   #ifdef PROTOBUF_FORCE_COPY_DEFAULT_STRING
     _impl_.platform_.Set("", GetArenaForAllocation());
   #endif // PROTOBUF_FORCE_COPY_DEFAULT_STRING
+  _impl_.kernelversion_.InitDefault();
+  #ifdef PROTOBUF_FORCE_COPY_DEFAULT_STRING
+    _impl_.kernelversion_.Set("", GetArenaForAllocation());
+  #endif // PROTOBUF_FORCE_COPY_DEFAULT_STRING
 }
 
 InfoBody::~InfoBody() {
@@ -379,6 +396,7 @@ inline void InfoBody::SharedDtor() {
   _impl_.main_.Destroy();
   _impl_.nodeenv_.Destroy();
   _impl_.platform_.Destroy();
+  _impl_.kernelversion_.Destroy();
 }
 
 void InfoBody::ArenaDtor(void* object) {
@@ -406,6 +424,7 @@ void InfoBody::Clear() {
   _impl_.main_.ClearToEmpty();
   _impl_.nodeenv_.ClearToEmpty();
   _impl_.platform_.ClearToEmpty();
+  _impl_.kernelversion_.ClearToEmpty();
   ::memset(&_impl_.cpucores_, 0, static_cast<size_t>(
       reinterpret_cast<char*>(&_impl_.totalmem_) -
       reinterpret_cast<char*>(&_impl_.cpucores_)) + sizeof(_impl_.totalmem_));
@@ -565,6 +584,16 @@ const char* InfoBody::_InternalParse(const char* ptr, ::_pbi::ParseContext* ctx)
             CHK_(ptr);
             if (!ctx->DataAvailable(ptr)) break;
           } while (::PROTOBUF_NAMESPACE_ID::internal::ExpectTag<122>(ptr));
+        } else
+          goto handle_unusual;
+        continue;
+      // string kernelVersion = 16;
+      case 16:
+        if (PROTOBUF_PREDICT_TRUE(static_cast<uint8_t>(tag) == 130)) {
+          auto str = _internal_mutable_kernelversion();
+          ptr = ::_pbi::InlineGreedyStringParser(str, ptr, ctx);
+          CHK_(ptr);
+          CHK_(::_pbi::VerifyUTF8(str, "grpcagent.InfoBody.kernelVersion"));
         } else
           goto handle_unusual;
         continue;
@@ -751,6 +780,16 @@ uint8_t* InfoBody::_InternalSerialize(
     }
   }
 
+  // string kernelVersion = 16;
+  if (!this->_internal_kernelversion().empty()) {
+    ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::VerifyUtf8String(
+      this->_internal_kernelversion().data(), static_cast<int>(this->_internal_kernelversion().length()),
+      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::SERIALIZE,
+      "grpcagent.InfoBody.kernelVersion");
+    target = stream->WriteStringMaybeAliased(
+        16, this->_internal_kernelversion(), target);
+  }
+
   if (PROTOBUF_PREDICT_FALSE(_internal_metadata_.have_unknown_fields())) {
     target = ::_pbi::WireFormat::InternalSerializeUnknownFieldsToArray(
         _internal_metadata_.unknown_fields<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(::PROTOBUF_NAMESPACE_ID::UnknownFieldSet::default_instance), target, stream);
@@ -847,6 +886,13 @@ size_t InfoBody::ByteSizeLong() const {
         this->_internal_platform());
   }
 
+  // string kernelVersion = 16;
+  if (!this->_internal_kernelversion().empty()) {
+    total_size += 2 +
+      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::StringSize(
+        this->_internal_kernelversion());
+  }
+
   // uint32 cpuCores = 3;
   if (this->_internal_cpucores() != 0) {
     total_size += ::_pbi::WireFormatLite::UInt32SizePlusOne(this->_internal_cpucores());
@@ -913,6 +959,9 @@ void InfoBody::MergeImpl(::PROTOBUF_NAMESPACE_ID::Message& to_msg, const ::PROTO
   }
   if (!from._internal_platform().empty()) {
     _this->_internal_set_platform(from._internal_platform());
+  }
+  if (!from._internal_kernelversion().empty()) {
+    _this->_internal_set_kernelversion(from._internal_kernelversion());
   }
   if (from._internal_cpucores() != 0) {
     _this->_internal_set_cpucores(from._internal_cpucores());
@@ -982,6 +1031,10 @@ void InfoBody::InternalSwap(InfoBody* other) {
   ::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::InternalSwap(
       &_impl_.platform_, lhs_arena,
       &other->_impl_.platform_, rhs_arena
+  );
+  ::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::InternalSwap(
+      &_impl_.kernelversion_, lhs_arena,
+      &other->_impl_.kernelversion_, rhs_arena
   );
   ::PROTOBUF_NAMESPACE_ID::internal::memswap<
       PROTOBUF_FIELD_OFFSET(InfoBody, _impl_.totalmem_)

--- a/agents/grpc/src/proto/info.pb.cc
+++ b/agents/grpc/src/proto/info.pb.cc
@@ -45,11 +45,11 @@ PROTOBUF_CONSTEXPR InfoBody::InfoBody(
   , /*decltype(_impl_.main_)*/{&::_pbi::fixed_address_empty_string, ::_pbi::ConstantInitialized{}}
   , /*decltype(_impl_.nodeenv_)*/{&::_pbi::fixed_address_empty_string, ::_pbi::ConstantInitialized{}}
   , /*decltype(_impl_.platform_)*/{&::_pbi::fixed_address_empty_string, ::_pbi::ConstantInitialized{}}
-  , /*decltype(_impl_.kernelversion_)*/{&::_pbi::fixed_address_empty_string, ::_pbi::ConstantInitialized{}}
   , /*decltype(_impl_.cpucores_)*/0u
   , /*decltype(_impl_.pid_)*/0u
   , /*decltype(_impl_.processstart_)*/uint64_t{0u}
   , /*decltype(_impl_.totalmem_)*/uint64_t{0u}
+  , /*decltype(_impl_.kernelversion_)*/0u
   , /*decltype(_impl_._cached_size_)*/{}} {}
 struct InfoBodyDefaultTypeInternal {
   PROTOBUF_CONSTEXPR InfoBodyDefaultTypeInternal()
@@ -142,7 +142,7 @@ const char descriptor_table_protodef_info_2eproto[] PROTOBUF_SECTION_VARIABLE(pr
   "\n \001(\r\022\020\n\010platform\030\013 \001(\t\022\024\n\014processStart\030"
   "\014 \001(\004\022\014\n\004tags\030\r \003(\t\022\020\n\010totalMem\030\016 \001(\004\0223\n"
   "\010versions\030\017 \003(\0132!.grpcagent.InfoBody.Ver"
-  "sionsEntry\022\025\n\rkernelVersion\030\020 \001(\t\032/\n\rVer"
+  "sionsEntry\022\025\n\rkernelVersion\030\020 \001(\r\032/\n\rVer"
   "sionsEntry\022\013\n\003key\030\001 \001(\t\022\r\n\005value\030\002 \001(\t:\002"
   "8\001\"Y\n\tInfoEvent\022)\n\006common\030\001 \001(\0132\031.grpcag"
   "ent.CommonResponse\022!\n\004body\030\002 \001(\0132\023.grpca"
@@ -212,11 +212,11 @@ InfoBody::InfoBody(const InfoBody& from)
     , decltype(_impl_.main_){}
     , decltype(_impl_.nodeenv_){}
     , decltype(_impl_.platform_){}
-    , decltype(_impl_.kernelversion_){}
     , decltype(_impl_.cpucores_){}
     , decltype(_impl_.pid_){}
     , decltype(_impl_.processstart_){}
     , decltype(_impl_.totalmem_){}
+    , decltype(_impl_.kernelversion_){}
     , /*decltype(_impl_._cached_size_)*/{}};
 
   _internal_metadata_.MergeFrom<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(from._internal_metadata_);
@@ -293,17 +293,9 @@ InfoBody::InfoBody(const InfoBody& from)
     _this->_impl_.platform_.Set(from._internal_platform(), 
       _this->GetArenaForAllocation());
   }
-  _impl_.kernelversion_.InitDefault();
-  #ifdef PROTOBUF_FORCE_COPY_DEFAULT_STRING
-    _impl_.kernelversion_.Set("", GetArenaForAllocation());
-  #endif // PROTOBUF_FORCE_COPY_DEFAULT_STRING
-  if (!from._internal_kernelversion().empty()) {
-    _this->_impl_.kernelversion_.Set(from._internal_kernelversion(), 
-      _this->GetArenaForAllocation());
-  }
   ::memcpy(&_impl_.cpucores_, &from._impl_.cpucores_,
-    static_cast<size_t>(reinterpret_cast<char*>(&_impl_.totalmem_) -
-    reinterpret_cast<char*>(&_impl_.cpucores_)) + sizeof(_impl_.totalmem_));
+    static_cast<size_t>(reinterpret_cast<char*>(&_impl_.kernelversion_) -
+    reinterpret_cast<char*>(&_impl_.cpucores_)) + sizeof(_impl_.kernelversion_));
   // @@protoc_insertion_point(copy_constructor:grpcagent.InfoBody)
 }
 
@@ -323,11 +315,11 @@ inline void InfoBody::SharedCtor(
     , decltype(_impl_.main_){}
     , decltype(_impl_.nodeenv_){}
     , decltype(_impl_.platform_){}
-    , decltype(_impl_.kernelversion_){}
     , decltype(_impl_.cpucores_){0u}
     , decltype(_impl_.pid_){0u}
     , decltype(_impl_.processstart_){uint64_t{0u}}
     , decltype(_impl_.totalmem_){uint64_t{0u}}
+    , decltype(_impl_.kernelversion_){0u}
     , /*decltype(_impl_._cached_size_)*/{}
   };
   _impl_.app_.InitDefault();
@@ -366,10 +358,6 @@ inline void InfoBody::SharedCtor(
   #ifdef PROTOBUF_FORCE_COPY_DEFAULT_STRING
     _impl_.platform_.Set("", GetArenaForAllocation());
   #endif // PROTOBUF_FORCE_COPY_DEFAULT_STRING
-  _impl_.kernelversion_.InitDefault();
-  #ifdef PROTOBUF_FORCE_COPY_DEFAULT_STRING
-    _impl_.kernelversion_.Set("", GetArenaForAllocation());
-  #endif // PROTOBUF_FORCE_COPY_DEFAULT_STRING
 }
 
 InfoBody::~InfoBody() {
@@ -396,7 +384,6 @@ inline void InfoBody::SharedDtor() {
   _impl_.main_.Destroy();
   _impl_.nodeenv_.Destroy();
   _impl_.platform_.Destroy();
-  _impl_.kernelversion_.Destroy();
 }
 
 void InfoBody::ArenaDtor(void* object) {
@@ -424,10 +411,9 @@ void InfoBody::Clear() {
   _impl_.main_.ClearToEmpty();
   _impl_.nodeenv_.ClearToEmpty();
   _impl_.platform_.ClearToEmpty();
-  _impl_.kernelversion_.ClearToEmpty();
   ::memset(&_impl_.cpucores_, 0, static_cast<size_t>(
-      reinterpret_cast<char*>(&_impl_.totalmem_) -
-      reinterpret_cast<char*>(&_impl_.cpucores_)) + sizeof(_impl_.totalmem_));
+      reinterpret_cast<char*>(&_impl_.kernelversion_) -
+      reinterpret_cast<char*>(&_impl_.cpucores_)) + sizeof(_impl_.kernelversion_));
   _internal_metadata_.Clear<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>();
 }
 
@@ -587,13 +573,11 @@ const char* InfoBody::_InternalParse(const char* ptr, ::_pbi::ParseContext* ctx)
         } else
           goto handle_unusual;
         continue;
-      // string kernelVersion = 16;
+      // uint32 kernelVersion = 16;
       case 16:
-        if (PROTOBUF_PREDICT_TRUE(static_cast<uint8_t>(tag) == 130)) {
-          auto str = _internal_mutable_kernelversion();
-          ptr = ::_pbi::InlineGreedyStringParser(str, ptr, ctx);
+        if (PROTOBUF_PREDICT_TRUE(static_cast<uint8_t>(tag) == 128)) {
+          _impl_.kernelversion_ = ::PROTOBUF_NAMESPACE_ID::internal::ReadVarint32(&ptr);
           CHK_(ptr);
-          CHK_(::_pbi::VerifyUTF8(str, "grpcagent.InfoBody.kernelVersion"));
         } else
           goto handle_unusual;
         continue;
@@ -780,14 +764,10 @@ uint8_t* InfoBody::_InternalSerialize(
     }
   }
 
-  // string kernelVersion = 16;
-  if (!this->_internal_kernelversion().empty()) {
-    ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::VerifyUtf8String(
-      this->_internal_kernelversion().data(), static_cast<int>(this->_internal_kernelversion().length()),
-      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::SERIALIZE,
-      "grpcagent.InfoBody.kernelVersion");
-    target = stream->WriteStringMaybeAliased(
-        16, this->_internal_kernelversion(), target);
+  // uint32 kernelVersion = 16;
+  if (this->_internal_kernelversion() != 0) {
+    target = stream->EnsureSpace(target);
+    target = ::_pbi::WireFormatLite::WriteUInt32ToArray(16, this->_internal_kernelversion(), target);
   }
 
   if (PROTOBUF_PREDICT_FALSE(_internal_metadata_.have_unknown_fields())) {
@@ -886,13 +866,6 @@ size_t InfoBody::ByteSizeLong() const {
         this->_internal_platform());
   }
 
-  // string kernelVersion = 16;
-  if (!this->_internal_kernelversion().empty()) {
-    total_size += 2 +
-      ::PROTOBUF_NAMESPACE_ID::internal::WireFormatLite::StringSize(
-        this->_internal_kernelversion());
-  }
-
   // uint32 cpuCores = 3;
   if (this->_internal_cpucores() != 0) {
     total_size += ::_pbi::WireFormatLite::UInt32SizePlusOne(this->_internal_cpucores());
@@ -911,6 +884,13 @@ size_t InfoBody::ByteSizeLong() const {
   // uint64 totalMem = 14;
   if (this->_internal_totalmem() != 0) {
     total_size += ::_pbi::WireFormatLite::UInt64SizePlusOne(this->_internal_totalmem());
+  }
+
+  // uint32 kernelVersion = 16;
+  if (this->_internal_kernelversion() != 0) {
+    total_size += 2 +
+      ::_pbi::WireFormatLite::UInt32Size(
+        this->_internal_kernelversion());
   }
 
   return MaybeComputeUnknownFieldsSize(total_size, &_impl_._cached_size_);
@@ -960,9 +940,6 @@ void InfoBody::MergeImpl(::PROTOBUF_NAMESPACE_ID::Message& to_msg, const ::PROTO
   if (!from._internal_platform().empty()) {
     _this->_internal_set_platform(from._internal_platform());
   }
-  if (!from._internal_kernelversion().empty()) {
-    _this->_internal_set_kernelversion(from._internal_kernelversion());
-  }
   if (from._internal_cpucores() != 0) {
     _this->_internal_set_cpucores(from._internal_cpucores());
   }
@@ -974,6 +951,9 @@ void InfoBody::MergeImpl(::PROTOBUF_NAMESPACE_ID::Message& to_msg, const ::PROTO
   }
   if (from._internal_totalmem() != 0) {
     _this->_internal_set_totalmem(from._internal_totalmem());
+  }
+  if (from._internal_kernelversion() != 0) {
+    _this->_internal_set_kernelversion(from._internal_kernelversion());
   }
   _this->_internal_metadata_.MergeFrom<::PROTOBUF_NAMESPACE_ID::UnknownFieldSet>(from._internal_metadata_);
 }
@@ -1032,13 +1012,9 @@ void InfoBody::InternalSwap(InfoBody* other) {
       &_impl_.platform_, lhs_arena,
       &other->_impl_.platform_, rhs_arena
   );
-  ::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr::InternalSwap(
-      &_impl_.kernelversion_, lhs_arena,
-      &other->_impl_.kernelversion_, rhs_arena
-  );
   ::PROTOBUF_NAMESPACE_ID::internal::memswap<
-      PROTOBUF_FIELD_OFFSET(InfoBody, _impl_.totalmem_)
-      + sizeof(InfoBody::_impl_.totalmem_)
+      PROTOBUF_FIELD_OFFSET(InfoBody, _impl_.kernelversion_)
+      + sizeof(InfoBody::_impl_.kernelversion_)
       - PROTOBUF_FIELD_OFFSET(InfoBody, _impl_.cpucores_)>(
           reinterpret_cast<char*>(&_impl_.cpucores_),
           reinterpret_cast<char*>(&other->_impl_.cpucores_));

--- a/agents/grpc/src/proto/info.pb.h
+++ b/agents/grpc/src/proto/info.pb.h
@@ -231,6 +231,7 @@ class InfoBody final :
     kMainFieldNumber = 8,
     kNodeEnvFieldNumber = 9,
     kPlatformFieldNumber = 11,
+    kKernelVersionFieldNumber = 16,
     kCpuCoresFieldNumber = 3,
     kPidFieldNumber = 10,
     kProcessStartFieldNumber = 12,
@@ -403,6 +404,20 @@ class InfoBody final :
   std::string* _internal_mutable_platform();
   public:
 
+  // string kernelVersion = 16;
+  void clear_kernelversion();
+  const std::string& kernelversion() const;
+  template <typename ArgT0 = const std::string&, typename... ArgT>
+  void set_kernelversion(ArgT0&& arg0, ArgT... args);
+  std::string* mutable_kernelversion();
+  PROTOBUF_NODISCARD std::string* release_kernelversion();
+  void set_allocated_kernelversion(std::string* kernelversion);
+  private:
+  const std::string& _internal_kernelversion() const;
+  inline PROTOBUF_ALWAYS_INLINE void _internal_set_kernelversion(const std::string& value);
+  std::string* _internal_mutable_kernelversion();
+  public:
+
   // uint32 cpuCores = 3;
   void clear_cpucores();
   uint32_t cpucores() const;
@@ -462,6 +477,7 @@ class InfoBody final :
     ::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr main_;
     ::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr nodeenv_;
     ::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr platform_;
+    ::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr kernelversion_;
     uint32_t cpucores_;
     uint32_t pid_;
     uint64_t processstart_;
@@ -1293,6 +1309,56 @@ inline ::PROTOBUF_NAMESPACE_ID::Map< std::string, std::string >*
 InfoBody::mutable_versions() {
   // @@protoc_insertion_point(field_mutable_map:grpcagent.InfoBody.versions)
   return _internal_mutable_versions();
+}
+
+// string kernelVersion = 16;
+inline void InfoBody::clear_kernelversion() {
+  _impl_.kernelversion_.ClearToEmpty();
+}
+inline const std::string& InfoBody::kernelversion() const {
+  // @@protoc_insertion_point(field_get:grpcagent.InfoBody.kernelVersion)
+  return _internal_kernelversion();
+}
+template <typename ArgT0, typename... ArgT>
+inline PROTOBUF_ALWAYS_INLINE
+void InfoBody::set_kernelversion(ArgT0&& arg0, ArgT... args) {
+ 
+ _impl_.kernelversion_.Set(static_cast<ArgT0 &&>(arg0), args..., GetArenaForAllocation());
+  // @@protoc_insertion_point(field_set:grpcagent.InfoBody.kernelVersion)
+}
+inline std::string* InfoBody::mutable_kernelversion() {
+  std::string* _s = _internal_mutable_kernelversion();
+  // @@protoc_insertion_point(field_mutable:grpcagent.InfoBody.kernelVersion)
+  return _s;
+}
+inline const std::string& InfoBody::_internal_kernelversion() const {
+  return _impl_.kernelversion_.Get();
+}
+inline void InfoBody::_internal_set_kernelversion(const std::string& value) {
+  
+  _impl_.kernelversion_.Set(value, GetArenaForAllocation());
+}
+inline std::string* InfoBody::_internal_mutable_kernelversion() {
+  
+  return _impl_.kernelversion_.Mutable(GetArenaForAllocation());
+}
+inline std::string* InfoBody::release_kernelversion() {
+  // @@protoc_insertion_point(field_release:grpcagent.InfoBody.kernelVersion)
+  return _impl_.kernelversion_.Release();
+}
+inline void InfoBody::set_allocated_kernelversion(std::string* kernelversion) {
+  if (kernelversion != nullptr) {
+    
+  } else {
+    
+  }
+  _impl_.kernelversion_.SetAllocated(kernelversion, GetArenaForAllocation());
+#ifdef PROTOBUF_FORCE_COPY_DEFAULT_STRING
+  if (_impl_.kernelversion_.IsDefault()) {
+    _impl_.kernelversion_.Set("", GetArenaForAllocation());
+  }
+#endif // PROTOBUF_FORCE_COPY_DEFAULT_STRING
+  // @@protoc_insertion_point(field_set_allocated:grpcagent.InfoBody.kernelVersion)
 }
 
 // -------------------------------------------------------------------

--- a/agents/grpc/src/proto/info.pb.h
+++ b/agents/grpc/src/proto/info.pb.h
@@ -231,11 +231,11 @@ class InfoBody final :
     kMainFieldNumber = 8,
     kNodeEnvFieldNumber = 9,
     kPlatformFieldNumber = 11,
-    kKernelVersionFieldNumber = 16,
     kCpuCoresFieldNumber = 3,
     kPidFieldNumber = 10,
     kProcessStartFieldNumber = 12,
     kTotalMemFieldNumber = 14,
+    kKernelVersionFieldNumber = 16,
   };
   // repeated string tags = 13;
   int tags_size() const;
@@ -404,20 +404,6 @@ class InfoBody final :
   std::string* _internal_mutable_platform();
   public:
 
-  // string kernelVersion = 16;
-  void clear_kernelversion();
-  const std::string& kernelversion() const;
-  template <typename ArgT0 = const std::string&, typename... ArgT>
-  void set_kernelversion(ArgT0&& arg0, ArgT... args);
-  std::string* mutable_kernelversion();
-  PROTOBUF_NODISCARD std::string* release_kernelversion();
-  void set_allocated_kernelversion(std::string* kernelversion);
-  private:
-  const std::string& _internal_kernelversion() const;
-  inline PROTOBUF_ALWAYS_INLINE void _internal_set_kernelversion(const std::string& value);
-  std::string* _internal_mutable_kernelversion();
-  public:
-
   // uint32 cpuCores = 3;
   void clear_cpucores();
   uint32_t cpucores() const;
@@ -454,6 +440,15 @@ class InfoBody final :
   void _internal_set_totalmem(uint64_t value);
   public:
 
+  // uint32 kernelVersion = 16;
+  void clear_kernelversion();
+  uint32_t kernelversion() const;
+  void set_kernelversion(uint32_t value);
+  private:
+  uint32_t _internal_kernelversion() const;
+  void _internal_set_kernelversion(uint32_t value);
+  public:
+
   // @@protoc_insertion_point(class_scope:grpcagent.InfoBody)
  private:
   class _Internal;
@@ -477,11 +472,11 @@ class InfoBody final :
     ::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr main_;
     ::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr nodeenv_;
     ::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr platform_;
-    ::PROTOBUF_NAMESPACE_ID::internal::ArenaStringPtr kernelversion_;
     uint32_t cpucores_;
     uint32_t pid_;
     uint64_t processstart_;
     uint64_t totalmem_;
+    uint32_t kernelversion_;
     mutable ::PROTOBUF_NAMESPACE_ID::internal::CachedSize _cached_size_;
   };
   union { Impl_ _impl_; };
@@ -1311,54 +1306,24 @@ InfoBody::mutable_versions() {
   return _internal_mutable_versions();
 }
 
-// string kernelVersion = 16;
+// uint32 kernelVersion = 16;
 inline void InfoBody::clear_kernelversion() {
-  _impl_.kernelversion_.ClearToEmpty();
+  _impl_.kernelversion_ = 0u;
 }
-inline const std::string& InfoBody::kernelversion() const {
+inline uint32_t InfoBody::_internal_kernelversion() const {
+  return _impl_.kernelversion_;
+}
+inline uint32_t InfoBody::kernelversion() const {
   // @@protoc_insertion_point(field_get:grpcagent.InfoBody.kernelVersion)
   return _internal_kernelversion();
 }
-template <typename ArgT0, typename... ArgT>
-inline PROTOBUF_ALWAYS_INLINE
-void InfoBody::set_kernelversion(ArgT0&& arg0, ArgT... args) {
- 
- _impl_.kernelversion_.Set(static_cast<ArgT0 &&>(arg0), args..., GetArenaForAllocation());
+inline void InfoBody::_internal_set_kernelversion(uint32_t value) {
+  
+  _impl_.kernelversion_ = value;
+}
+inline void InfoBody::set_kernelversion(uint32_t value) {
+  _internal_set_kernelversion(value);
   // @@protoc_insertion_point(field_set:grpcagent.InfoBody.kernelVersion)
-}
-inline std::string* InfoBody::mutable_kernelversion() {
-  std::string* _s = _internal_mutable_kernelversion();
-  // @@protoc_insertion_point(field_mutable:grpcagent.InfoBody.kernelVersion)
-  return _s;
-}
-inline const std::string& InfoBody::_internal_kernelversion() const {
-  return _impl_.kernelversion_.Get();
-}
-inline void InfoBody::_internal_set_kernelversion(const std::string& value) {
-  
-  _impl_.kernelversion_.Set(value, GetArenaForAllocation());
-}
-inline std::string* InfoBody::_internal_mutable_kernelversion() {
-  
-  return _impl_.kernelversion_.Mutable(GetArenaForAllocation());
-}
-inline std::string* InfoBody::release_kernelversion() {
-  // @@protoc_insertion_point(field_release:grpcagent.InfoBody.kernelVersion)
-  return _impl_.kernelversion_.Release();
-}
-inline void InfoBody::set_allocated_kernelversion(std::string* kernelversion) {
-  if (kernelversion != nullptr) {
-    
-  } else {
-    
-  }
-  _impl_.kernelversion_.SetAllocated(kernelversion, GetArenaForAllocation());
-#ifdef PROTOBUF_FORCE_COPY_DEFAULT_STRING
-  if (_impl_.kernelversion_.IsDefault()) {
-    _impl_.kernelversion_.Set("", GetArenaForAllocation());
-  }
-#endif // PROTOBUF_FORCE_COPY_DEFAULT_STRING
-  // @@protoc_insertion_point(field_set_allocated:grpcagent.InfoBody.kernelVersion)
 }
 
 // -------------------------------------------------------------------

--- a/lib/nsolid.js
+++ b/lib/nsolid.js
@@ -52,6 +52,7 @@ const {
   clearFatalError,
   nsolid_consts,
   nsolid_counts,
+  getKernelVersion,
 } = binding;
 
 const DEFAULT_HOSTNAME = getHostname();
@@ -268,6 +269,7 @@ function genInfoObject(regen = false) {
     // lib/os.js for reference.
     cpuCores: ArrayIsArray(cpuData) ? cpuData.length / 7 : null,
     cpuModel: ArrayIsArray(cpuData) ? cpuData[0] : null,
+    kernelVersion: getKernelVersion(),
   };
 
   // In IISNODE environment, the processes are launched in the following way:

--- a/src/nsolid/nsolid_api.cc
+++ b/src/nsolid/nsolid_api.cc
@@ -17,6 +17,10 @@
 
 #include <cmath>
 
+#if defined(__linux__)
+#include <sys/utsname.h>
+#endif
+
 #define MICROS_PER_SEC 1000000
 #define NANOS_PER_SEC 1000000000
 
@@ -2533,6 +2537,23 @@ static void GetConfigVersion(const FunctionCallbackInfo<Value>& args) {
   args.GetReturnValue().Set(EnvList::Inst()->current_config_version());
 }
 
+static void GetKernelVersion(const FunctionCallbackInfo<Value>& args) {
+  std::string kernel_version = "";
+
+#ifdef __linux__
+  // Retrieve the kernel version only on Linux
+  // as we are going to use it to collect eBPF information
+  struct utsname info;
+  if (uname(&info) == 0) {
+    kernel_version = info.release;
+  }
+#endif
+
+  // Return the kernel version, or empty string if not supported/failed
+  args.GetReturnValue().Set(
+      String::NewFromUtf8(args.GetIsolate(), kernel_version.c_str())
+          .ToLocalChecked());
+}
 
 static void PauseMetrics(const FunctionCallbackInfo<Value>& args) {
   EnvInst* envinst = EnvInst::GetEnvLocalInst(args.GetIsolate());
@@ -2956,6 +2977,7 @@ void BindingData::Initialize(Local<Object> target,
   SetMethod(context, target, "getStartupTimes", GetStartupTimes);
   SetMethod(context, target, "getConfig", GetConfig);
   SetMethod(context, target, "getConfigVersion", GetConfigVersion);
+  SetMethod(context, target, "getKernelVersion", GetKernelVersion);
   SetMethod(context, target, "pauseMetrics", PauseMetrics);
   SetMethod(context, target, "resumeMetrics", ResumeMetrics);
   SetMethod(context, target, "setMetricsInterval", SetMetricsInterval);
@@ -3088,6 +3110,7 @@ void BindingData::RegisterExternalReferences(
   registry->Register(GetStartupTimes);
   registry->Register(GetConfig);
   registry->Register(GetConfigVersion);
+  registry->Register(GetKernelVersion);
   registry->Register(PauseMetrics);
   registry->Register(ResumeMetrics);
   registry->Register(SetMetricsInterval);

--- a/src/nsolid/nsolid_api.cc
+++ b/src/nsolid/nsolid_api.cc
@@ -2545,7 +2545,7 @@ uint32_t calculateKernelVersion() {
   uint32_t major;
   uint32_t minor;
   uint32_t patch;
-  char v_sig[256];
+  std::string v_sig;
   char* needle;
 
   if (version != 0) return version;
@@ -2557,8 +2557,9 @@ uint32_t calculateKernelVersion() {
    *   Ubuntu 5.15.0-79.86-generic 5.15.111
    */
 
-  if (0 == ReadFileSync("/proc/version_signature", v_sig))
-    if (3 == sscanf(v_sig, "Ubuntu %*s %u.%u.%u", &major, &minor, &patch))
+  if (0 == ReadFileSync(&v_sig, "/proc/version_signature"))
+    if (3 ==
+        sscanf(v_sig.c_str(), "Ubuntu %*s %u.%u.%u", &major, &minor, &patch))
       goto calculate_version;
 
   if (-1 == uname(&u)) return 0;

--- a/src/nsolid/nsolid_api.cc
+++ b/src/nsolid/nsolid_api.cc
@@ -2537,22 +2537,90 @@ static void GetConfigVersion(const FunctionCallbackInfo<Value>& args) {
   args.GetReturnValue().Set(EnvList::Inst()->current_config_version());
 }
 
-static void GetKernelVersion(const FunctionCallbackInfo<Value>& args) {
-  std::string kernel_version = "";
-
 #ifdef __linux__
-  // Retrieve the kernel version only on Linux
-  // as we are going to use it to collect eBPF information
-  struct utsname info;
-  if (uname(&info) == 0) {
-    kernel_version = info.release;
+
+uint32_t calculateKernelVersion() {
+  struct utsname u;
+  static uint32_t version = 0;
+  uint32_t major;
+  uint32_t minor;
+  uint32_t patch;
+  char v_sig[256];
+  char* needle;
+
+  if (version != 0) return version;
+
+  /* Check /proc/version_signature first as it's the way to get the mainline
+   * kernel version in Ubuntu. The format is:
+   *   Ubuntu ubuntu_kernel_version mainline_kernel_version
+   * For example:
+   *   Ubuntu 5.15.0-79.86-generic 5.15.111
+   */
+
+  if (0 == ReadFileSync("/proc/version_signature", v_sig))
+    if (3 == sscanf(v_sig, "Ubuntu %*s %u.%u.%u", &major, &minor, &patch))
+      goto calculate_version;
+
+  if (-1 == uname(&u)) return 0;
+
+  /* In Debian we need to check `version` instead of `release` to extract the
+   * mainline kernel version. This is an example of how it looks like:
+   *  #1 SMP Debian 5.10.46-4 (2021-08-03)
+   */
+  needle = strstr(u.version, "Debian ");
+  if (needle != nullptr)
+    if (3 == sscanf(needle, "Debian %u.%u.%u", &major, &minor, &patch))
+      goto calculate_version;
+
+  if (3 != sscanf(u.release, "%u.%u.%u", &major, &minor, &patch)) return 0;
+
+  /* Handle it when the process runs under the UNAME26 personality:
+   *
+   * - kernels >= 3.x identify as 2.6.40+x
+   * - kernels >= 4.x identify as 2.6.60+x
+   *
+   * UNAME26 is a poorly conceived hack that doesn't let us distinguish
+   * between 4.x kernels and 5.x/6.x kernels so we conservatively assume
+   * that 2.6.60+x means 4.x.
+   *
+   * Fun fact of the day: it's technically possible to observe the actual
+   * kernel version for a brief moment because uname() first copies out the
+   * real release string before overwriting it with the backcompat string.
+   */
+  if (major == 2 && minor == 6) {
+    if (patch >= 60) {
+      major = 4;
+      minor = patch - 60;
+      patch = 0;
+    } else if (patch >= 40) {
+      major = 3;
+      minor = patch - 40;
+      patch = 0;
+    }
   }
+
+calculate_version:
+  version = major * 65536 + minor * 256 + patch;
+
+  return version;
+}
 #endif
 
-  // Return the kernel version, or empty string if not supported/failed
-  args.GetReturnValue().Set(
-      String::NewFromUtf8(args.GetIsolate(), kernel_version.c_str())
-          .ToLocalChecked());
+static void GetKernelVersion(const FunctionCallbackInfo<Value>& args) {
+  static uint32_t kernel_version = 0;
+
+#ifdef __linux__
+  if (kernel_version != 0) {
+    args.GetReturnValue().Set(kernel_version);
+    return;
+  }
+
+  // Retrieve the kernel version only on Linux
+  // as we are going to use it to collect eBPF information
+  kernel_version = calculateKernelVersion();
+#endif
+
+  args.GetReturnValue().Set(kernel_version);
 }
 
 static void PauseMetrics(const FunctionCallbackInfo<Value>& args) {

--- a/test/addons/nsolid-get-info/nsolid-get-info.js
+++ b/test/addons/nsolid-get-info/nsolid-get-info.js
@@ -72,7 +72,7 @@ const expectedInfoFormat = {
   },
   cpuCores: [ isNumber ],
   cpuModel: [ isString ],
-  kernelVersion: [ isString ],
+  kernelVersion: [ isNumber ],
 };
 
 const infoProps = Object.keys(info);
@@ -81,6 +81,12 @@ const expectedInfoProps = Object.keys(expectedInfoFormat);
 // causes its removal.
 assert.ok(infoProps.length === expectedInfoProps.length ||
           infoProps.length + 1 === expectedInfoProps.length);
+
+if (process.platform === 'linux') {
+  assert.ok(info.kernelVersion !== 0, 'Linux kernel version should not be 0');
+} else {
+  assert.ok(info.kernelVersion === 0, `Kernel version should be 0 on ${process.platform}`);
+}
 
 function checkPropsInObject(obj, expected) {
   Object.keys(expected).forEach((k) => {

--- a/test/addons/nsolid-get-info/nsolid-get-info.js
+++ b/test/addons/nsolid-get-info/nsolid-get-info.js
@@ -72,6 +72,7 @@ const expectedInfoFormat = {
   },
   cpuCores: [ isNumber ],
   cpuModel: [ isString ],
+  kernelVersion: [ isString ],
 };
 
 const infoProps = Object.keys(info);

--- a/test/agents/test-grpc-info.mjs
+++ b/test/agents/test-grpc-info.mjs
@@ -60,6 +60,7 @@ if (process.argv[2] === 'child') {
     assert.strictEqual(info.body.tags.length, nsolidConfig.tags ? nsolidConfig.tags.length : 0);
     assert.ok(info.body.totalMem);
     assert.deepStrictEqual(info.body.versions, process.versions);
+    assert.strictEqual(typeof info.body.kernelVersion, 'string');
     assert.ok(metadata['user-agent']);
     assert.ok(metadata['nsolid-agent-id']);
     assert.strictEqual(metadata['nsolid-agent-id'][0], agentId);

--- a/test/agents/test-grpc-info.mjs
+++ b/test/agents/test-grpc-info.mjs
@@ -60,7 +60,7 @@ if (process.argv[2] === 'child') {
     assert.strictEqual(info.body.tags.length, nsolidConfig.tags ? nsolidConfig.tags.length : 0);
     assert.ok(info.body.totalMem);
     assert.deepStrictEqual(info.body.versions, process.versions);
-    assert.strictEqual(typeof info.body.kernelVersion, 'string');
+    assert.strictEqual(typeof info.body.kernelVersion, 'number');
     assert.ok(metadata['user-agent']);
     assert.ok(metadata['nsolid-agent-id']);
     assert.strictEqual(metadata['nsolid-agent-id'][0], agentId);

--- a/test/parallel/test-nsolid-info.js
+++ b/test/parallel/test-nsolid-info.js
@@ -76,8 +76,12 @@ if (process.argv[2]) {
   assert.deepStrictEqual(info.tags, tags);
   assert.strictEqual(info.totalMem, totalMem);
   assert.strictEqual(info.totalMem, os.totalmem());
-  assert.strictEqual(typeof info.kernelVersion, 'string');
-  assert.ok(info.kernelVersion.length > 0);
+  assert.strictEqual(typeof info.kernelVersion, 'number');
+  if (common.isLinux) {
+    assert.ok(info.kernelVersion !== 0);
+  } else {
+    assert.strictEqual(info.kernelVersion, 0);
+  }
 } else {
   const env = {};
   const stdio = 'inherit';

--- a/test/parallel/test-nsolid-info.js
+++ b/test/parallel/test-nsolid-info.js
@@ -76,7 +76,8 @@ if (process.argv[2]) {
   assert.deepStrictEqual(info.tags, tags);
   assert.strictEqual(info.totalMem, totalMem);
   assert.strictEqual(info.totalMem, os.totalmem());
-  assert.deepStrictEqual(info.versions, process.versions);
+  assert.strictEqual(typeof info.kernelVersion, 'string');
+  assert.ok(info.kernelVersion.length > 0);
 } else {
   const env = {};
   const stdio = 'inherit';


### PR DESCRIPTION
Refs: https://github.com/nodesource/ebpf-roadmap/issues/1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a new field to report the Linux kernel version in system information.
  - The kernel version is now accessible via the API and included in relevant info objects.

- **Tests**
  - Updated tests to verify that the kernel version is provided as a numeric value on Linux and zero on other platforms.
  - Modified assertions to check the presence and type of the kernel version in info objects.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->