### PR TITLE
src: remove cap check when loading ebpf programs

### DIFF
--- a/src/nsolid/nsolid_bpf.h
+++ b/src/nsolid/nsolid_bpf.h
@@ -88,12 +88,6 @@ class EbpfLoader {
 #undef V
 
   EbpfLoadStatus LoadProgram(const std::string& program_name) {
-    EBPFSupportInfo info = detectEBPFSupport();
-
-    if (!info.is_supported || !info.has_sys_admin_capability) {
-      return EbpfLoadStatus::NOT_SUPPORTED;
-    }
-
 #ifdef __linux__
 #define V(name, _, prog)                                                       \
   if (program_name == prog) return Load##name();


### PR DESCRIPTION
**src: remove cap check when loading ebpf programs**
```
We have decided to "brute-force" the eBPF programs and if it fail due to any CAP
permission, we return a LOAD_ERROR to the user
```