### PR TITLE
src: add GetBuildId helper function

### DIFF
--- a/node.gyp
+++ b/node.gyp
@@ -573,6 +573,12 @@
       }, {
         'use_openssl_def%': 0,
       }],
+      [ 'OS=="linux"', {
+        'nsolid_sources': [
+          'src/nsolid/nsolid_elf_utils.cc',
+          'src/nsolid/nsolid_elf_utils.h',
+        ]
+      }],
     ],
   },
 

--- a/node.gypi
+++ b/node.gypi
@@ -550,10 +550,13 @@
     [ 'OS=="sunos"', {
       'ldflags': [ '-Wl,-M,/usr/lib/ld/map.noexstk' ],
     }],
-    [ 'OS=="linux" and not nsolid_use_librt', {
-      'libraries!': [
-        '-lrt'
-      ],
+    [ 'OS=="linux"', {
+      'libraries': [ '-lelf' ],
+      'conditions': [
+        [ 'not nsolid_use_librt', {
+          'libraries!': [ '-lrt' ],
+        }]
+      ]
     }],
     [ 'OS in "freebsd linux"', {
       'ldflags': [ '-Wl,-z,relro',

--- a/src/nsolid/nsolid_elf_utils.cc
+++ b/src/nsolid/nsolid_elf_utils.cc
@@ -1,0 +1,97 @@
+#include "nsolid_elf_utils.h"
+#include "nsolid_util.h"
+
+#include <fcntl.h>
+#include <libelf.h>
+#include <gelf.h>
+#include <unistd.h>
+#include <cstring>
+#include <map>
+#include "uv.h"
+
+namespace node {
+namespace nsolid {
+namespace elf_utils {
+
+
+int GetBuildId(const std::string& path, std::string* build_id) {
+  static std::map<std::string, std::string> build_id_cache_;
+
+  Elf* e;
+  Elf_Scn* scn = nullptr;
+  GElf_Shdr shdr;
+
+  if (build_id_cache_.find(path) != build_id_cache_.end()) {
+    *build_id = build_id_cache_[path];
+    return 0;
+  }
+
+  int ret;
+
+  ret = 0;
+  if (elf_version(EV_CURRENT) == EV_NONE) {
+    return elf_errno();
+  }
+
+  int fd = open(path.c_str(), O_RDONLY);
+  if (fd < 0) {
+    return -errno;
+  }
+
+  e = elf_begin(fd, ELF_C_READ, nullptr);
+  if (!e) {
+    ret = elf_errno();
+    goto error;
+  }
+
+  size_t shstrndx;
+  if (elf_getshdrstrndx(e, &shstrndx) != 0) {
+    ret = elf_errno();
+    goto end_error;
+  }
+
+  *build_id = std::string("");
+  while ((scn = elf_nextscn(e, scn)) != nullptr) {
+    if (gelf_getshdr(scn, &shdr) != &shdr) {
+      ret = elf_errno();
+      goto end_error;
+    }
+
+    char* name = elf_strptr(e, shstrndx, shdr.sh_name);
+    if (name && strcmp(name, ".note.gnu.build-id") == 0) {
+      Elf_Data* data = elf_getdata(scn, nullptr);
+      if (data && data->d_size >= 16) {
+        // ELF Note header: namesz(4), descsz(4), type(4) + name padding
+        // Compute offset to build-id properly
+        uint32_t* note = reinterpret_cast<uint32_t*>(data->d_buf);
+        uint32_t namesz = note[0];
+        uint32_t descsz = note[1];
+        // Name starts at offset 12
+        // Descriptor (build-id) starts at next aligned offset
+        size_t name_end = 12 + ((namesz + 3) & ~3);
+        uint8_t* id = reinterpret_cast<uint8_t*>(data->d_buf) + name_end;
+        *build_id = utils::buffer_to_hex(id, descsz);
+        break;
+      }
+    }
+  }
+
+  if (build_id->empty()) {
+    ret = UV_ENOENT;
+  } else {
+    build_id_cache_[path] = *build_id;
+  }
+
+end_error:
+  elf_end(e);
+
+error:
+  close(fd);
+
+  return ret;
+}
+
+}  // namespace elf_utils
+}  // namespace nsolid
+}  // namespace node
+

--- a/src/nsolid/nsolid_elf_utils.h
+++ b/src/nsolid/nsolid_elf_utils.h
@@ -1,0 +1,19 @@
+#ifndef SRC_NSOLID_NSOLID_ELF_UTILS_H_
+#define SRC_NSOLID_NSOLID_ELF_UTILS_H_
+
+#if defined(NODE_WANT_INTERNALS) && NODE_WANT_INTERNALS
+
+#include <string>
+
+namespace node {
+namespace nsolid {
+
+namespace elf_utils {
+  int GetBuildId(const std::string& path, std::string* build_id);
+}  // namespace elf_utils
+}  // namespace nsolid
+}  // namespace node
+
+#endif  // defined(NODE_WANT_INTERNALS) && NODE_WANT_INTERNALS
+
+#endif  // SRC_NSOLID_NSOLID_ELF_UTILS_H_

--- a/test/addons/nsolid-elf-utils/binding.cc
+++ b/test/addons/nsolid-elf-utils/binding.cc
@@ -1,0 +1,32 @@
+#include <node.h>
+#include <v8.h>
+#include <string>
+#if defined(__linux__)
+#include "../../../src/nsolid/nsolid_elf_utils.h"
+#endif
+
+using v8::FunctionCallbackInfo;
+using v8::Isolate;
+using v8::String;
+using v8::Value;
+
+static void GetBuildId(const FunctionCallbackInfo<Value>& args) {
+#if defined(__linux__)
+  Isolate* isolate = args.GetIsolate();
+  assert(args[0]->IsString());
+  v8::String::Utf8Value path_utf8(isolate, args[0]);
+  std::string path(*path_utf8, path_utf8.length());
+  std::string build_id;
+  int res = node::nsolid::elf_utils::GetBuildId(path, &build_id);
+  if (res != 0) {
+    return;
+  }
+
+  args.GetReturnValue().Set(
+    String::NewFromUtf8(isolate, build_id.c_str()).ToLocalChecked());
+#endif
+}
+
+NODE_MODULE_INIT(/* exports, module, context */) {
+  NODE_SET_METHOD(exports, "getBuildId", GetBuildId);
+}

--- a/test/addons/nsolid-elf-utils/binding.gyp
+++ b/test/addons/nsolid-elf-utils/binding.gyp
@@ -1,0 +1,10 @@
+{
+  'targets': [
+    {
+      'target_name': 'binding',
+      'sources': [ 'binding.cc' ],
+      'includes': ['../common.gypi'],
+      'defines': [ 'NODE_WANT_INTERNALS=1' ],
+    }
+  ]
+}

--- a/test/addons/nsolid-elf-utils/nsolid-elf-utils.js
+++ b/test/addons/nsolid-elf-utils/nsolid-elf-utils.js
@@ -1,0 +1,23 @@
+'use strict';
+const common = require('../../common');
+const assert = require('assert');
+const { execSync } = require('child_process');
+const process = require('process');
+
+// Only run on Linux
+if (process.platform !== 'linux') {
+  console.log('Skipping: nsolid-elf-utils only supported on Linux');
+  process.exit(0);
+}
+
+const bindingPath = require.resolve(`./build/${common.buildType}/binding`);
+const binding = require(bindingPath);
+
+const expected =
+  execSync(`readelf -n ${process.execPath} | awk '/Build ID/ { print $3 }'`,
+           { encoding: 'utf8' }).trim();
+
+const buildId = binding.getBuildId(process.execPath);
+assert.strictEqual(buildId,
+                   expected,
+                   `Mismatch: addon='${buildId}', readelf='${expected}'`);


### PR DESCRIPTION
To allow us to read the Build-Id from ELF headers in a specific binary.

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a native addon method to retrieve the GNU build ID from ELF binaries on Linux.
* **Tests**
  * Introduced a test script to verify that the native addon correctly extracts the build ID, comparing its output to the system's `readelf` command.
* **Chores**
  * Updated build configuration to always link with the ELF library on Linux and conditionally exclude the real-time library.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->