### PR TITLE
build,deps,src: bring back v8 abseil-cpp

### DIFF
--- a/agents/grpc/src/grpc_agent.cc
+++ b/agents/grpc/src/grpc_agent.cc
@@ -3,6 +3,7 @@
 #include "asserts-cpp/asserts.h"
 #include "debug_utils-inl.h"
 #include "nsolid/nsolid_api.h"
+#include "nsolid/continuous_profiler.h"
 #include "nsolid/nsolid_util.h"
 #include "../../otlp/src/otlp_common.h"
 #include "../../src/root_certs.h"

--- a/deps/grpc/grpc.gyp
+++ b/deps/grpc/grpc.gyp
@@ -81,7 +81,7 @@
         'CARES_STATICLIB',
       ],
       'dependencies': [
-        '../protobuf/abseil.gyp:abseil',
+        '../protobuf/abseil.gyp:abseil_proto',
         'address_sorting',
         'upb',
         're2',
@@ -695,6 +695,7 @@
         'src/core/lib/promise/activity.cc',
         'src/core/lib/promise/party.cc',
         'src/core/lib/promise/sleep.cc',
+        'src/core/lib/promise/wait_set.cc',
         'src/core/lib/resource_quota/api.cc',
         'src/core/lib/resource_quota/arena.cc',
         'src/core/lib/resource_quota/connection_quota.cc',
@@ -994,7 +995,7 @@
       'dependencies': [
         'grpc',
         'upb',
-        '../protobuf/abseil.gyp:abseil',
+        '../protobuf/abseil.gyp:abseil_proto',
         '../protobuf/utf8_range.gyp:utf8_range',
         '../openssl/openssl.gyp:openssl',
       ],
@@ -1072,7 +1073,7 @@
       ],
       'dependencies': [
         '../protobuf/protobuf.gyp:protobuf',
-        '../protobuf/abseil.gyp:abseil',
+        '../protobuf/abseil.gyp:abseil_proto',
       ],
       'include_dirs': [
         './',

--- a/deps/opentelemetry-cpp/otlp-http-exporter.gyp
+++ b/deps/opentelemetry-cpp/otlp-http-exporter.gyp
@@ -68,7 +68,7 @@
         '../protobuf/protobuf.gyp:protobuf',
         '../curl/curl.gyp:curl',
         '../grpc/grpc.gyp:grpc++',
-	'../protobuf/abseil.gyp:abseil',
+	'../protobuf/abseil.gyp:abseil_proto',
         '../zlib/zlib.gyp:zlib',
       ],
       'direct_dependent_settings': {

--- a/deps/protobuf/abseil.gyp
+++ b/deps/protobuf/abseil.gyp
@@ -1,7 +1,7 @@
 {
   'targets': [
     {
-      'target_name': 'abseil',
+      'target_name': 'abseil_proto',
       'type': 'static_library',
       'variables': {
         'ABSEIL_ROOT': 'third_party/abseil-cpp',

--- a/deps/protobuf/protobuf.gyp
+++ b/deps/protobuf/protobuf.gyp
@@ -7,7 +7,7 @@
       'HAVE_PTHREAD'
     ],
     'dependencies': [
-      './abseil.gyp:abseil',
+      './abseil.gyp:abseil_proto',
     ],
     'cflags_cc': [
       '-Wall',

--- a/deps/protobuf/utf8_range.gyp
+++ b/deps/protobuf/utf8_range.gyp
@@ -4,7 +4,7 @@
       'target_name': 'utf8_range',
       'type': 'static_library',
       'dependencies': [
-        './abseil.gyp:abseil',
+        './abseil.gyp:abseil_proto',
       ],
       'direct_dependent_settings': {
         'include_dirs': [

--- a/node.gyp
+++ b/node.gyp
@@ -977,7 +977,8 @@
         'deps/googletest/googletest.gyp:gtest_prod',
         'deps/histogram/histogram.gyp:histogram',
         'deps/nbytes/nbytes.gyp:nbytes',
-        'deps/protobuf/abseil.gyp:abseil',
+        'deps/protobuf/abseil.gyp:abseil_proto',
+        'tools/v8_gypfiles/abseil.gyp:abseil',
         'node_js2c#host',
       ],
 
@@ -1316,7 +1317,8 @@
         'deps/googletest/googletest.gyp:gtest_main',
         'deps/histogram/histogram.gyp:histogram',
         'deps/nbytes/nbytes.gyp:nbytes',
-        'deps/protobuf/abseil.gyp:abseil',
+        'deps/protobuf/abseil.gyp:abseil_proto',
+        'tools/v8_gypfiles/abseil.gyp:abseil',
       ],
 
       'includes': [

--- a/src/nsolid/nsolid_api.h
+++ b/src/nsolid/nsolid_api.h
@@ -18,7 +18,6 @@
 #include "node_snapshotable.h"
 #include "nsolid.h"
 #include "nsuv-inl.h"
-#include "continuous_profiler.h"
 #include "nsolid_heap_snapshot.h"
 #include "nsolid_trace.h"
 #include "nsolid_util.h"

--- a/tools/v8_gypfiles/v8.gyp
+++ b/tools/v8_gypfiles/v8.gyp
@@ -261,7 +261,7 @@
         'v8_base_without_compiler',
         'v8_initializers',
         'v8_maybe_icu',
-        '../../deps/protobuf/abseil.gyp:abseil',
+        'abseil.gyp:abseil',
       ],
       'sources': [
         '<(V8_ROOT)/src/init/setup-isolate-full.cc',
@@ -277,7 +277,7 @@
       'dependencies': [
         'generate_bytecode_builtins_list',
         'run_torque',
-        '../../deps/protobuf/abseil.gyp:abseil',
+        'abseil.gyp:abseil',
       ],
       'cflags!': ['-O3'],
       'cflags': ['-O1'],
@@ -305,7 +305,7 @@
         'v8_base_without_compiler',
         'v8_shared_internal_headers',
         'v8_pch',
-        '../../deps/protobuf/abseil.gyp:abseil',
+        'abseil.gyp:abseil',
       ],
       'include_dirs': [
         '<(SHARED_INTERMEDIATE_DIR)',
@@ -495,6 +495,7 @@
             'v8_compiler_for_mksnapshot',
             'v8_initializers',
             'v8_libplatform',
+            'abseil.gyp:abseil',
           ]
         }],
         ['OS=="win" and clang==1', {
@@ -609,7 +610,7 @@
         'run_torque',
         'v8_libbase',
         'fp16',
-        '../../deps/protobuf/abseil.gyp:abseil',
+        'abseil.gyp:abseil',
       ],
       'direct_dependent_settings': {
         'sources': [
@@ -938,7 +939,7 @@
         'v8_shared_internal_headers',
         'v8_turboshaft',
         'v8_pch',
-        '../../deps/protobuf/abseil.gyp:abseil',
+        'abseil.gyp:abseil',
       ],
       'conditions': [
         ['v8_enable_turbofan==1', {
@@ -961,7 +962,7 @@
         'v8_libbase',
         'v8_shared_internal_headers',
         'v8_pch',
-        '../../deps/protobuf/abseil.gyp:abseil',
+        'abseil.gyp:abseil',
       ],
       'sources': [
         '<!@pymod_do_main(GN-scraper "<(V8_ROOT)/BUILD.gn"  "v8_source_set.\\"v8_turboshaft.*?sources = ")',
@@ -1082,7 +1083,7 @@
         'v8_zlib',
         'v8_pch',
         'fp16',
-        '../../deps/protobuf/abseil.gyp:abseil',
+        'abseil.gyp:abseil',
       ],
       'includes': ['inspector.gypi'],
       'direct_dependent_settings': {
@@ -1802,7 +1803,7 @@
         'v8_maybe_icu',
         'v8_turboshaft',
         'v8_pch',
-        '../../deps/protobuf/abseil.gyp:abseil',
+        'abseil.gyp:abseil',
         # "build/win:default_exe_manifest",
       ],
       'sources': [


### PR DESCRIPTION
Make sure v8 is built with its own abseil-cpp version while the other
dependencies use the one from protobuffer.
In order to avoid name collisions when building `libnsolid`, a new
`libagents` target has been added.
Also, commented `AbslInternalGetFileMappingHint` from protobuf's
abseil-cpp to avoid collisions, as it's defined outside a namespace.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated build configurations to refine dependency management and modularization of source files.
  * Adjusted references to Abseil dependencies across multiple components for improved clarity and separation.
  * No changes to user-facing features or functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->