### PR TITLE
src: handle nameless user @ ProcessMetrics::Update

### DIFF
--- a/src/nsolid.cc
+++ b/src/nsolid.cc
@@ -211,14 +211,18 @@ int ProcessMetrics::Update() {
   char title_buf[512];
   size_t rss;
   int er;
+  // uv_get_process_title() may fail. Leave `title` empty and continue.
+  std::string title;
   // uv_os_get_passwd() may fail (e.g., nameless system user). Leave `user`
   // empty and continue.
   std::string user;
 
   uv_loadavg(load_avgs);
   er = uv_get_process_title(title_buf, sizeof(title_buf));
-  if (er)
-    return er;
+  if (er == 0) {
+    title = title_buf;
+  }
+
   er = uv_resident_set_memory(&rss);
   if (er)
     return er;
@@ -244,7 +248,7 @@ int ProcessMetrics::Update() {
   cpu_percent[2] = (cpu[2] - cpu_prev_[2]) * 100.0 * 1000.0 / elapsed;
 
   uv_mutex_lock(&stor_lock_);
-  stor_.title = title_buf;
+  stor_.title = title;
   stor_.user = user;
   stor_.timestamp = duration_cast<milliseconds>(
     system_clock::now().time_since_epoch()).count();

--- a/src/nsolid.cc
+++ b/src/nsolid.cc
@@ -211,6 +211,9 @@ int ProcessMetrics::Update() {
   char title_buf[512];
   size_t rss;
   int er;
+  // uv_os_get_passwd() may fail (e.g., nameless system user). Leave `user`
+  // empty and continue.
+  std::string user;
 
   uv_loadavg(load_avgs);
   er = uv_get_process_title(title_buf, sizeof(title_buf));
@@ -231,9 +234,10 @@ int ProcessMetrics::Update() {
   if (er)
     return er;
   er = uv_os_get_passwd(&pwd);
-  if (er)
-    return er;
-  auto free_passwd = OnScopeLeave([&]() { uv_os_free_passwd(&pwd); });
+  if (er == 0) {
+    auto free_passwd = OnScopeLeave([&]() { uv_os_free_passwd(&pwd); });
+    user = pwd.username;
+  }
 
   cpu_percent[0] = (cpu[0] - cpu_prev_[0]) * 100.0 * 1000.0 / elapsed;
   cpu_percent[1] = (cpu[1] - cpu_prev_[1]) * 100.0 * 1000.0 / elapsed;
@@ -241,7 +245,7 @@ int ProcessMetrics::Update() {
 
   uv_mutex_lock(&stor_lock_);
   stor_.title = title_buf;
-  stor_.user = pwd.username;
+  stor_.user = user;
   stor_.timestamp = duration_cast<milliseconds>(
     system_clock::now().time_since_epoch()).count();
   stor_.uptime =


### PR DESCRIPTION
If nsolid is running as a user without a name (e.g. system user), uv_os_get_passwd may fail. This change ensures ProcessMetrics::Update still fills metrics and does not return early in that case, leaving the user field empty instead of failing the update.

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - None.
- Bug Fixes
  - Improved resilience of process metrics collection: failures to fetch process title or user no longer stop the update cycle.
  - Metrics now continue to refresh with partial data when lookups fail, avoiding gaps in reporting.
  - The user or title fields may be blank if the system cannot provide them, instead of causing errors.
- Refactor
  - Simplified control flow to reduce early exits during metrics updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->