### PR TITLE
src: clamp idle_diff before computing proc_diff

### DIFF
--- a/src/nsolid/nsolid_api.cc
+++ b/src/nsolid/nsolid_api.cc
@@ -611,6 +611,10 @@ void EnvInst::uv_metrics_cb_(nsuv::ns_prepare* handle, EnvInst* envinst) {
   // Use the previous values to calculate the values for this loop iteration.
   loop_duration = metrics_cb_time - envinst->prev_metrics_cb_time_;
   loop_idle_time = idle_time - envinst->prev_loop_idle_time_;
+  // Clamp loop_idle_time to avoid unsigned underflow in loop_proc_time when
+  // clock skew causes idle_time to be slightly larger than loop_duration.
+  if (loop_idle_time > loop_duration)
+    loop_idle_time = loop_duration;
   loop_proc_time = loop_duration - loop_idle_time;
   events_procd = metrics->events - envinst->prev_events_processed_;
   events_waiting = metrics->events_waiting - envinst->prev_events_waiting_;
@@ -2162,6 +2166,12 @@ void EnvInst::get_event_loop_stats_(EnvInst* envinst,
   uint64_t loop_idle_time = uv_metrics_idle_time(envinst->event_loop());
   uint64_t loop_diff = stor->current_hrtime_ - stor->prev_call_time_;
   uint64_t idle_diff = loop_idle_time - stor->prev_idle_time_;
+  // On some platforms the clocks backing loop_diff and idle_diff can differ by
+  // a few hundred nanoseconds when the loop is nearly 100% idle, making
+  // idle_diff slightly larger than loop_diff. Clamp to avoid unsigned
+  // underflow in proc_diff and bogus utilization values.
+  if (idle_diff > loop_diff)
+    idle_diff = loop_diff;
   uint64_t proc_diff = loop_diff - idle_diff;
   uint64_t count_diff = metrics->loop_count - stor->loop_iterations;
   auto entry_exit = envinst->provider_times();


### PR DESCRIPTION
Avoid unsigned underflow when loop_diff is slightly larger than idle_diff due to clock skew on idle loops.

Fixes: https://github.com/nodesource/nsolid-private/issues/15

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Clamped event-loop and idle time calculations to prevent unsigned underflow.
  * Corrected idle-vs-loop comparisons to avoid negative diffs producing bogus utilization.
  * Reduced spurious spikes in reported event-loop usage for more reliable monitoring.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->