### PR TITLE
agents: guard StartWritesDone() in grpc streams

### DIFF
--- a/agents/grpc/src/asset_stream.cc
+++ b/agents/grpc/src/asset_stream.cc
@@ -67,8 +67,11 @@ void AssetStream::OnWriteDone(bool ok/*ok*/) {
   if (!ok) {
     Debug("AssetStream::OnWriteDone not ok\n");
     write_state_.done = true;
-    StartWritesDone();
-    RemoveHold();
+    if (!write_state_.writes_done) {
+      write_state_.writes_done = true;
+      StartWritesDone();
+      RemoveHold();
+    }
   } else {
     NextWrite();
   }
@@ -80,8 +83,11 @@ void AssetStream::NextWrite() {
       StartWrite(&write_state_.asset);
       write_state_.write_done = false;
     } else if (write_state_.write_done_called) {
-      StartWritesDone();
-      RemoveHold();
+      if (!write_state_.writes_done) {
+        write_state_.writes_done = true;
+        StartWritesDone();
+        RemoveHold();
+      }
     }
   }
 }

--- a/agents/grpc/src/asset_stream.h
+++ b/agents/grpc/src/asset_stream.h
@@ -39,6 +39,7 @@ class AssetStream: public ::grpc::ClientWriteReactor<grpcagent::Asset> {
     bool done = false;
     bool write_done = true;
     bool write_done_called = false;
+    bool writes_done = false;
     grpcagent::Asset asset;
   };
 

--- a/agents/grpc/src/command_stream.cc
+++ b/agents/grpc/src/command_stream.cc
@@ -79,8 +79,14 @@ void CommandStream::OnReadDone(bool ok) {
     Debug("CommandStream::OnReadDone not ok\n");
   }
 
-  StartWritesDone();
-  RemoveHold();
+  {
+    nsuv::ns_mutex::scoped_lock lock(lock_);
+    if (!write_state_.writes_done) {
+      write_state_.writes_done = true;
+      StartWritesDone();
+      RemoveHold();
+    }
+  }
 }
 
 void CommandStream::OnWriteDone(bool ok/*ok*/) {
@@ -88,8 +94,11 @@ void CommandStream::OnWriteDone(bool ok/*ok*/) {
   write_state_.write_done = true;
   if (!ok) {
     Debug("CommandStream::OnWriteDone not ok\n");
-    StartWritesDone();
-    RemoveHold();
+    if (!write_state_.writes_done) {
+      write_state_.writes_done = true;
+      StartWritesDone();
+      RemoveHold();
+    }
   } else {
     NextWrite();
   }

--- a/agents/grpc/src/command_stream.h
+++ b/agents/grpc/src/command_stream.h
@@ -23,6 +23,7 @@ class CommandStream:
                                    grpcagent::CommandRequest> {
   struct WriteState {
     bool write_done = true;
+    bool writes_done = false;
     bool done = false;
     grpcagent::CommandResponse resp;
   };


### PR DESCRIPTION
Ensure CommandStream and AssetStream call StartWritesDone only once to avoid crashes.
Add writes_done flags and locks to prevent concurrent error resends. Document NextWrite expectation that callers hold the mutex.

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented duplicate completion signals in stream write handling so finalization runs only once.
  * Guarded finalization steps to avoid repeated shutdown behavior, reducing risk of deadlocks and missed cleanup.
  * Strengthened synchronization across the write lifecycle for more reliable, deterministic stream termination and improved stability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->