### PR TITLE
agents: fix infinite recursion on ~CommandStream

### DIFF
--- a/agents/grpc/src/command_stream.cc
+++ b/agents/grpc/src/command_stream.cc
@@ -31,6 +31,7 @@ CommandStream::~CommandStream() {
   nsuv::ns_mutex::scoped_lock lock(lock_);
   // try cancel and wait until OnDone is called
   if (!write_state_.done) {
+    cancelling_for_destruction_ = true;
     context_.TryCancel();
     do {
       uv_cond_wait(&on_done_cond_, lock_.base());
@@ -53,12 +54,11 @@ void CommandStream::OnDone(const Status& s) {
     nsuv::ns_mutex::scoped_lock lock(lock_);
     write_state_.done = true;
     uv_cond_signal(&on_done_cond_);
-    if (!obs) {
+    if (!obs || cancelling_for_destruction_) {
       return;
     }
   }
 
-  // Don't notify the observer if the stream was cancelled (destroyed)
   obs->on_command_stream_done(s);
 }
 

--- a/agents/grpc/src/command_stream.h
+++ b/agents/grpc/src/command_stream.h
@@ -60,6 +60,7 @@ class CommandStream:
   TSQueue<grpcagent::CommandResponse> response_q_;
   nsuv::ns_mutex lock_;
   uv_cond_t on_done_cond_;
+  bool cancelling_for_destruction_ = false;
 };
 
 }  // namespace grpc

--- a/test/agents/test-grpc-basic.mjs
+++ b/test/agents/test-grpc-basic.mjs
@@ -126,6 +126,61 @@ tests.push({
   },
 });
 
+tests.push({
+  name: 'should reconnect after initial invalid NSOLID_GRPC',
+  test: async (getEnv, isSecure) => {
+    return new Promise((resolve) => {
+      const grpcServer = new GRPCServer({ tls: isSecure });
+      grpcServer.start(mustSucceed(async (port) => {
+        grpcServer.on('exit', mustCall((data) => {
+          checkExitData(data.msg, data.metadata, agentId, { code: 0, error: null, profile: '' });
+          grpcServer.close();
+          resolve();
+        }));
+
+        const correctEnv = getEnv(port, isSecure);
+        const env = {
+          NODE_DEBUG_NATIVE: 'nsolid_grpc_agent',
+          NSOLID_GRPC: '127.0.0.1:1',
+        };
+        if (correctEnv.NSOLID_GRPC_INSECURE) {
+          env.NSOLID_GRPC_INSECURE = correctEnv.NSOLID_GRPC_INSECURE;
+        }
+        if (correctEnv.NSOLID_GRPC_CERTS) {
+          env.NSOLID_GRPC_CERTS = correctEnv.NSOLID_GRPC_CERTS;
+        }
+
+        const opts = {
+          stdio: ['inherit', 'inherit', 'inherit', 'ipc'],
+          env,
+        };
+        const child = new TestClient([], opts);
+        const agentId = await child.id();
+
+        const config = {};
+        if (correctEnv.NSOLID_GRPC) {
+          config.grpc = correctEnv.NSOLID_GRPC;
+        }
+        if (correctEnv.NSOLID_SAAS) {
+          config.saas = correctEnv.NSOLID_SAAS;
+        }
+
+        grpcServer.on('command', async ({ agentId }) => {
+          // Verify the CommandStream is working by sending a command from server to client
+          const infoResult = await grpcServer.info(agentId);
+          assert.ok(infoResult);
+          const exit = await child.shutdown(0);
+          assert.ok(exit);
+          assert.strictEqual(exit.code, 0);
+          assert.strictEqual(exit.signal, null);
+        });
+
+        await child.config(config);
+      }));
+    });
+  },
+});
+
 const testConfigs = [
   {
     getEnv: (port, isSecure) => {


### PR DESCRIPTION
When trying to reset a CommandStream because of reasons: for example, we change `grpc` endpoint dynamically, we can enter an infinite recursion calling `GrpcAgent::reset_command_stream()` because when calling `~CommandStream()` the `OnDone()` callback may call the observer (GrpcAgent instance) which in turn would call
`GrpcAgent::reset_command_stream()`. Avoid this recursion by adding a new `cancelling_for_destruction_` member variable to `CommandStream` which allows avoiding calling the observer if triggered by the destructor.

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Suppress observer notifications during object destruction and ensure cancellation completes cleanly to improve shutdown reliability.

* **Tests**
  * Added a test covering reconnection and configuration recovery after an invalid initial setup, verifying command delivery and a clean client shutdown.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->