### PR TITLE
agents: fix http_client percentile calculation

### DIFF
--- a/agents/otlp/src/otlp_common.cc
+++ b/agents/otlp/src/otlp_common.cc
@@ -347,8 +347,8 @@ NSOLID_ENV_METRICS_NUMBERS(V)
               use_snake_case ? "http_client" : "httpClient",
               kNSMSecs,
               InstrumentValueType::kDouble,
-              {{ 0.5, stor.http_client99_ptile },
-               { 0.99, stor.http_client_median }},
+              {{ 0.5, stor.http_client_median },
+               { 0.99, stor.http_client99_ptile }},
               attrs);
   add_summary(metrics,
               process_start,

--- a/test/agents/test-grpc-metrics.mjs
+++ b/test/agents/test-grpc-metrics.mjs
@@ -196,6 +196,8 @@ function checkScopeMetrics(scopeMetrics) {
       if (dataPoint.quantileValues[1].value) {
         validateNumber(dataPoint.quantileValues[1].value, `${name}.quantileValues[1].value`);
       }
+
+      assert.ok(dataPoint.quantileValues[0].value >= dataPoint.quantileValues[1].value, `p99 ${name} should be >= p50 ${name}`);
     } else {
       assert.strictEqual(dataPoint.value, expectedMetric[2]);
       if (type === 'asInt') {
@@ -235,9 +237,13 @@ async function runTest({ getEnv }) {
         stdio: ['inherit', 'inherit', 'inherit', 'ipc'],
         env,
       };
-      const child = new TestClient([], opts);
+      const child = new TestClient(['-t', 'http'], opts);
       const agentId = await child.id();
-      const config = await child.config({ app: 'my_app_name', interval: 100 });
+      const config = await child.config({ app: 'my_app_name' });
+      for (let i = 0; i < 10; i++) {
+        await child.trace('http');
+      }
+
       grpcServer.once('metrics', mustCall(async () => {
         const metrics = await child.metrics();
         assert.strictEqual(config.app, 'my_app_name');
@@ -258,7 +264,6 @@ const testConfigs = [
         NODE_DEBUG_NATIVE: 'nsolid_grpc_agent',
         NSOLID_GRPC_INSECURE: 1,
         NSOLID_GRPC: `localhost:${port}`,
-        NSOLID_INTERVAL: 10000,
       };
     },
   },
@@ -268,7 +273,6 @@ const testConfigs = [
         NODE_DEBUG_NATIVE: 'nsolid_grpc_agent',
         NSOLID_GRPC_INSECURE: 1,
         NSOLID_SAAS: `aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaabbbbbbbbbbbbbbbbbbbbbbbbbbbbbtesting.localhost:${port}`,
-        NSOLID_INTERVAL: 10000,
       };
     },
   },


### PR DESCRIPTION
p50 and p99 where flipped.

Improved `test/agents/test-grpc-metrics.mjs` to make sure we don't regress.

Fixes: https://github.com/nodesource/nsolid/issues/423

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed HTTP client percentile mapping so median and p99 latency are reported to the correct metrics.

* **Tests**
  * Strengthened metrics tests: validate p99 ≥ p50, emit multiple HTTP traces before asserting, run tests against HTTP targets, and simplified agent configuration by removing an obsolete interval setting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->