### PR TITLE
src,test: preserve Latin1 strings in fastSpan APIs

### DIFF
--- a/src/nsolid/nsolid_api.cc
+++ b/src/nsolid/nsolid_api.cc
@@ -10,11 +10,13 @@
 #include "util.h"
 #include "env-inl.h"
 #include "uv.h"
+#include "node_debug.h"
 #include "node_internals.h"
 #include "node_external_reference.h"
 #include "memory_tracker-inl.h"
 #include "node_perf.h"
 #include "node_url.h"
+#include "simdutf.h"
 #include "v8-fast-api-calls.h"
 
 #include <algorithm>
@@ -92,6 +94,16 @@ constexpr uint64_t datapoints_q_interval = 100;
 constexpr size_t datapoints_q_max_size = 100;
 
 static const char* get_startuptime_name(const char* name);
+
+static std::string OneByteToUtf8(const FastOneByteString& input) {
+  std::string out;
+  out.resize(input.length * 2);
+
+  const size_t actual_length = simdutf::convert_latin1_to_utf8(
+      input.data, input.length, out.data());
+  out.resize(actual_length);
+  return out;
+}
 
 
 EnvInst::EnvInst(Environment* env)
@@ -2474,10 +2486,11 @@ void BindingData::FastPushSpanDataString(v8::Local<v8::Object> receiver,
                                          uint32_t trace_id,
                                          uint32_t type,
                                          const FastOneByteString& val) {
+  TRACK_V8_FAST_API_CALL("nsolid.pushSpanDataString");
   PushSpanDataStringImpl(FromJSObject<BindingData>(receiver),
                          trace_id,
                          type,
-                         std::string(val.data, val.length));
+                         OneByteToUtf8(val));
 }
 
 
@@ -2521,12 +2534,13 @@ void BindingData::FastPushSpanDataString3(v8::Local<v8::Object> receiver,
                                           const FastOneByteString& val1,
                                           const FastOneByteString& val2,
                                           const FastOneByteString& val3) {
+  TRACK_V8_FAST_API_CALL("nsolid.pushSpanDataString3");
   PushSpanDataStringImpl3(FromJSObject<BindingData>(receiver),
-                         trace_id,
-                         type,
-                         std::string(val1.data, val1.length),
-                         std::string(val2.data, val2.length),
-                         std::string(val3.data, val3.length));
+                          trace_id,
+                          type,
+                         OneByteToUtf8(val1),
+                         OneByteToUtf8(val2),
+                         OneByteToUtf8(val3));
 }
 
 void BindingData::PushSpanDataStringImpl3(BindingData* data,

--- a/test/addons/nsolid-tracing/test-fast-api-string-latin1.js
+++ b/test/addons/nsolid-tracing/test-fast-api-string-latin1.js
@@ -1,0 +1,89 @@
+// Flags: --expose-internals --no-warnings --allow-natives-syntax
+'use strict';
+
+const common = require('../../common');
+const assert = require('assert');
+const { internalBinding } = require('internal/test/binding');
+const { checkTracesOnExit } = require('../../common/nsolid-traces');
+const { setupNSolid } = require('./utils');
+const fixtures = require('../../common/fixtures');
+const addonBindingPath = require.resolve(`./build/${common.buildType}/binding`);
+const addonBinding = require(addonBindingPath);
+
+const nsolidBinding = internalBinding('nsolid_api');
+const { nsolid_consts } = nsolidBinding;
+const nsolid = require('nsolid');
+const api = require(require.resolve('@opentelemetry/api',
+                                    { paths: [fixtures.fixturesDir] }));
+
+const expectedTraces = [
+  {
+    attributes: {
+      'http.url': 'http://localhost/ma\u00f1ana',
+    },
+    end_reason: addonBinding.kSpanEndOk,
+    name: 'Espa\u00f1a',
+    parentId: '0000000000000000',
+    thread_id: 0,
+    kind: addonBinding.kClient,
+    type: addonBinding.kSpanCustom,
+    status: {
+      code: api.SpanStatusCode.OK,
+    },
+  },
+];
+
+checkTracesOnExit(addonBinding, expectedTraces);
+
+setupNSolid({ lookup: false }, common.mustCall(() => {
+  if (!nsolid.otel.register(api)) {
+    throw new Error('Error registering api');
+  }
+
+  const tracer = api.trace.getTracer('test');
+  const span = tracer.startSpan('initial_name', { kind: api.SpanKind.CLIENT });
+
+  function pushSpanName() {
+    nsolidBinding.pushSpanDataString(span.internalId,
+                                     nsolid_consts.kSpanName,
+                                     'Espa\u00f1a');
+  }
+
+  function pushSpanUrl() {
+    nsolidBinding.pushSpanDataString3(span.internalId,
+                                      nsolid_consts.kSpanHttpReqUrl,
+                                      'http:',
+                                      'localhost',
+                                      '/ma\u00f1ana');
+  }
+
+  if (common.isDebug) {
+    const { getV8FastApiCallCount } = internalBinding('debug');
+    assert.strictEqual(getV8FastApiCallCount('nsolid.pushSpanDataString'), 0);
+    assert.strictEqual(getV8FastApiCallCount('nsolid.pushSpanDataString3'), 0);
+
+    eval('%PrepareFunctionForOptimization(pushSpanName)');
+    pushSpanName();
+    eval('%PrepareFunctionForOptimization(pushSpanUrl)');
+    pushSpanUrl();
+
+    assert.strictEqual(getV8FastApiCallCount('nsolid.pushSpanDataString'), 0);
+    assert.strictEqual(getV8FastApiCallCount('nsolid.pushSpanDataString3'), 0);
+
+    eval('%OptimizeFunctionOnNextCall(pushSpanName)');
+    pushSpanName();
+    eval('%OptimizeFunctionOnNextCall(pushSpanUrl)');
+    pushSpanUrl();
+
+    assert.strictEqual(getV8FastApiCallCount('nsolid.pushSpanDataString'), 1);
+    assert.strictEqual(getV8FastApiCallCount('nsolid.pushSpanDataString3'), 1);
+  } else {
+    pushSpanName();
+    pushSpanUrl();
+  }
+
+  span.setStatus({ code: api.SpanStatusCode.OK });
+  span.end();
+
+  setTimeout(() => {}, 100);
+}));

--- a/test/addons/nsolid-tracing/test-otel-basic.js
+++ b/test/addons/nsolid-tracing/test-otel-basic.js
@@ -23,6 +23,7 @@ const expectedTraces = [
       c: 3,
       d: 4,
       e: 5,
+      latin1: 'Espa\u00f1a',
     },
     events: [
       {
@@ -69,6 +70,7 @@ setupNSolid(common.mustCall(() => {
   assert.strictEqual(span.updateName('my name'), span);
   assert.strictEqual(span.setAttributes({ c: 3, d: 4 }), span);
   assert.strictEqual(span.setAttribute('e', 5), span);
+  assert.strictEqual(span.setAttribute('latin1', 'Espa\u00f1a'), span);
   assert.strictEqual(span.addEvent('my_event 1', Date.now()), span);
   assert.strictEqual(
     span.addEvent('my_event 2', { attr1: 'val1', attr2: 'val2' }, Date.now()),

--- a/test/agents/test-grpc-tracing.mjs
+++ b/test/agents/test-grpc-tracing.mjs
@@ -53,6 +53,7 @@ const expectedCustomAttributes = (threadId) => {
     'b': [ 'intValue', '2', false ],
     'c': [ 'intValue', '3', false ],
     'd': [ 'intValue', '4', false ],
+    'latin1': [ 'stringValue', 'Espa\u00f1a', false ],
     'e': [ 'arrayValue', [
       { stringValue: 'abAD', value: 'stringValue' },
       { stringValue: 'cdCF', value: 'stringValue' },

--- a/test/common/nsolid-grpc-agent/client.js
+++ b/test/common/nsolid-grpc-agent/client.js
@@ -98,6 +98,7 @@ function execCustomTrace() {
     const span = tracer.startSpan('initial_name', { attributes: { a: 1, b: 2 },
                                                     kind: api.SpanKind.CLIENT });
     span.setAttributes({ c: 3, d: 4 })
+        .setAttribute('latin1', 'Espa\u00f1a')
         .setAttribute('e', [ 'abAD', 'cdCF'])
         .addEvent('my_event 1', Date.now())
         .addEvent('my_event 2', { attr1: 'val1', attr2: 'val2' }, Date.now());


### PR DESCRIPTION
Convert FastOneByteString inputs to UTF-8 before storing span string data so non-ASCII Latin-1 values such as ñ are emitted correctly by the N|Solid fast tracing bindings.

Add tracing coverage for Latin-1 custom attributes and introduce a debug-only fast-path test that uses TRACK_V8_FAST_API_CALL to verify pushSpanDataString() and pushSpanDataString3() actually execute through the V8 fast API path.

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of Latin‑1 (non‑ASCII) strings in span data so trace names, attributes and URLs are correctly encoded as UTF‑8.

* **Tests**
  * Added a test validating native string handling for Latin‑1 characters.
  * Updated multiple tests and expected trace assertions to include Latin‑1 span attributes and URL parts.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nodesource/nsolid/pull/450)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->