### PR TITLE
src: enrich OTLP metrics resource attributes

### DIFF
--- a/agents/grpc/src/grpc_agent.cc
+++ b/agents/grpc/src/grpc_agent.cc
@@ -284,7 +284,8 @@ void PopulateMetricsEvent(grpcagent::MetricsEvent* metrics_event,
   PopulateCommon(metrics_event->mutable_common(), "metrics", req_id);
 
   ResourceMetrics data;
-  data.resource_ = otlp::GetResource();
+  auto resource = otlp::GetMetricsResource();
+  data.resource_ = resource.get();
   std::vector<MetricData> metrics;
 
   // As this is the cached we're sending, we pass the same value for prev_stor.
@@ -969,7 +970,8 @@ void GrpcAgent::env_deletion_cb_(SharedEnvInst envinst,
   }
 
   ResourceMetrics data;
-  data.resource_ = otlp::GetResource();
+  auto resource = otlp::GetMetricsResource();
+  data.resource_ = resource.get();
   std::vector<MetricData> metrics;
 
   ThreadMetricsStor stor;
@@ -1414,7 +1416,8 @@ void GrpcAgent::got_proc_metrics() {
   std::vector<MetricData> metrics;
   otlp::fill_proc_metrics(metrics, stor, proc_prev_stor_, false);
   ResourceMetrics data;
-  data.resource_ = otlp::GetResource();
+  auto resource = otlp::GetMetricsResource();
+  data.resource_ = resource.get();
   data.scope_metric_data_ =
     std::vector<ScopeMetrics>{{otlp::GetScope(), metrics}};
   auto result = metrics_exporter_->Export(data);

--- a/agents/grpc/src/grpc_agent.cc
+++ b/agents/grpc/src/grpc_agent.cc
@@ -256,7 +256,8 @@ void PopulateMetricsEvent(grpcagent::MetricsEvent* metrics_event,
   PopulateCommon(metrics_event->mutable_common(), "metrics", req_id);
 
   ResourceMetrics data;
-  data.resource_ = otlp::GetResource();
+  auto resource = otlp::GetMetricsResource();
+  data.resource_ = resource.get();
   std::vector<MetricData> metrics;
 
   // As this is the cached we're sending, we pass the same value for prev_stor.
@@ -936,7 +937,8 @@ void GrpcAgent::env_deletion_cb_(SharedEnvInst envinst,
   }
 
   ResourceMetrics data;
-  data.resource_ = otlp::GetResource();
+  auto resource = otlp::GetMetricsResource();
+  data.resource_ = resource.get();
   std::vector<MetricData> metrics;
 
   ThreadMetricsStor stor;
@@ -1381,7 +1383,8 @@ void GrpcAgent::got_proc_metrics() {
   std::vector<MetricData> metrics;
   otlp::fill_proc_metrics(metrics, stor, proc_prev_stor_, false);
   ResourceMetrics data;
-  data.resource_ = otlp::GetResource();
+  auto resource = otlp::GetMetricsResource();
+  data.resource_ = resource.get();
   data.scope_metric_data_ =
     std::vector<ScopeMetrics>{{otlp::GetScope(), metrics}};
   auto result = metrics_exporter_->Export(data);

--- a/agents/otlp/src/otlp_common.cc
+++ b/agents/otlp/src/otlp_common.cc
@@ -202,7 +202,7 @@ static ResourceAttributes GetMetadataResourceAttributes(const json& info) {
 
   it = info.find("cpuCores");
   if (it != info.end() && it->is_number_unsigned()) {
-    attrs.SetAttribute("cpuCores", std::to_string(it->get<uint32_t>()));
+    attrs.SetAttribute("cpuCores", it->get<uint32_t>());
   }
 
   it = info.find("cpuModel");

--- a/agents/otlp/src/otlp_common.cc
+++ b/agents/otlp/src/otlp_common.cc
@@ -1,10 +1,17 @@
 #include "otlp_common.h"
 // NOLINTNEXTLINE(build/c++11)
 #include <chrono>
+#include <ctime>
+#include <iomanip>
+#include <sstream>
 #include <unordered_map>
 #include "asserts-cpp/asserts.h"
 #include "env-inl.h"
 #include "nlohmann/json.hpp"
+#include "nsuv-inl.h"
+#include "opentelemetry/semconv/incubating/deployment_attributes.h"
+#include "opentelemetry/semconv/incubating/host_attributes.h"
+#include "opentelemetry/semconv/incubating/os_attributes.h"
 #include "opentelemetry/semconv/incubating/process_attributes.h"
 #include "opentelemetry/semconv/incubating/service_attributes.h"
 #include "opentelemetry/semconv/incubating/thread_attributes.h"
@@ -44,8 +51,20 @@ using opentelemetry::trace::SpanId;
 using opentelemetry::trace::SpanKind;
 using opentelemetry::trace::TraceFlags;
 using opentelemetry::trace::TraceId;
+using opentelemetry::semconv::deployment::kDeploymentEnvironmentName;
+using opentelemetry::semconv::host::kHostArch;
+using opentelemetry::semconv::host::kHostCpuModelName;
+using opentelemetry::semconv::host::kHostName;
+using opentelemetry::semconv::os::kOsType;
 using opentelemetry::trace::propagation::detail::HexToBinary;
+using opentelemetry::semconv::process::kProcessCreationTime;
+using opentelemetry::semconv::process::kProcessExecutablePath;
 using opentelemetry::semconv::process::kProcessOwner;
+using opentelemetry::semconv::process::kProcessPid;
+using opentelemetry::semconv::process::kProcessRuntimeDescription;
+using opentelemetry::semconv::process::kProcessRuntimeName;
+using opentelemetry::semconv::process::kProcessRuntimeVersion;
+using opentelemetry::semconv::process::kProcessTitle;
 using opentelemetry::semconv::service::kServiceName;
 using opentelemetry::semconv::service::kServiceInstanceId;
 using opentelemetry::semconv::service::kServiceVersion;
@@ -67,9 +86,235 @@ static std::vector<std::string> discarded_metrics = {
   "thread_id", "timestamp"
 };
 
-static std::unique_ptr<Resource> resource_g =
-  std::make_unique<Resource>(Resource::GetEmpty());
-static bool isResourceInitialized_g = false;
+static std::shared_ptr<Resource> resource_g;
+static std::shared_ptr<Resource> metrics_resource_g;
+
+static nsuv::ns_mutex& ResourceMutex() {
+  static int er = 0;
+  static nsuv::ns_mutex mutex(&er, false);
+  ASSERT_EQ(0, er);
+  return mutex;
+}
+
+static std::string ToIso8601(uint64_t timestamp_ms) {
+  if (timestamp_ms == 0) return "";
+
+  const time_t seconds = static_cast<time_t>(timestamp_ms / 1000);
+  std::tm tm{};
+#ifdef _WIN32
+  gmtime_s(&tm, &seconds);
+#else
+  gmtime_r(&seconds, &tm);
+#endif
+
+  std::ostringstream stream;
+  stream << std::put_time(&tm, "%Y-%m-%dT%H:%M:%S");
+
+  const uint64_t millis = timestamp_ms % 1000;
+  stream << '.' << std::setw(3) << std::setfill('0') << millis;
+
+  stream << 'Z';
+  return stream.str();
+}
+
+static std::string NormalizeOsType(const std::string& platform) {
+  if (platform == "win32") return "windows";
+  if (platform == "sunos") return "solaris";
+  return platform;
+}
+
+static std::string NormalizeHostArch(const std::string& arch) {
+  if (arch == "x64") return "amd64";
+  if (arch == "ia32") return "x86";
+  if (arch == "arm") return "arm32";
+  return arch;
+}
+
+static ResourceAttributes GetMetadataResourceAttributes(const json& info) {
+  ResourceAttributes attrs;
+
+  if (info.is_discarded() || !info.is_object()) return attrs;
+
+  auto it = info.find("app");
+  if (it != info.end() && it->is_string()) {
+    attrs.SetAttribute(kServiceName, it->get<std::string>());
+  }
+
+  attrs.SetAttribute(kServiceInstanceId, nsolid::GetAgentId());
+
+  it = info.find("appVersion");
+  if (it != info.end() && it->is_string()) {
+    attrs.SetAttribute(kServiceVersion, it->get<std::string>());
+  }
+
+  it = info.find("hostname");
+  if (it != info.end() && it->is_string()) {
+    attrs.SetAttribute(kHostName, it->get<std::string>());
+  }
+
+  it = info.find("pid");
+  if (it != info.end() && it->is_number_unsigned()) {
+    attrs.SetAttribute(kProcessPid, static_cast<int64_t>(it->get<uint32_t>()));
+  }
+
+  it = info.find("arch");
+  if (it != info.end() && it->is_string()) {
+    attrs.SetAttribute(kHostArch, NormalizeHostArch(it->get<std::string>()));
+  }
+
+  it = info.find("platform");
+  if (it != info.end() && it->is_string()) {
+    attrs.SetAttribute(kOsType, NormalizeOsType(it->get<std::string>()));
+  }
+
+  it = info.find("execPath");
+  if (it != info.end() && it->is_string()) {
+    attrs.SetAttribute(kProcessExecutablePath, it->get<std::string>());
+  }
+
+  it = info.find("main");
+  if (it != info.end() && it->is_string()) {
+    attrs.SetAttribute("main", it->get<std::string>());
+  }
+
+  it = info.find("nodeEnv");
+  if (it != info.end() && it->is_string()) {
+    attrs.SetAttribute(kDeploymentEnvironmentName, it->get<std::string>());
+  }
+
+  it = info.find("versions");
+  if (it != info.end() && it->is_object()) {
+    auto version_it = it->find("node");
+    if (version_it != it->end() && version_it->is_string()) {
+      attrs.SetAttribute(kProcessRuntimeVersion,
+                         version_it->get<std::string>());
+    }
+
+    version_it = it->find("nsolid");
+    if (version_it != it->end() && version_it->is_string()) {
+      std::string nsolid_version = version_it->get<std::string>();
+      attrs.SetAttribute(kProcessRuntimeDescription,
+                         "N|Solid " + nsolid_version);
+    }
+  }
+
+  attrs.SetAttribute(kProcessRuntimeName, "nodejs");
+
+  it = info.find("cpuCores");
+  if (it != info.end() && it->is_number_unsigned()) {
+    attrs.SetAttribute("cpuCores", it->get<uint32_t>());
+  }
+
+  it = info.find("cpuModel");
+  if (it != info.end() && it->is_string()) {
+    attrs.SetAttribute(kHostCpuModelName, it->get<std::string>());
+  }
+
+  it = info.find("processStart");
+  if (it != info.end() && it->is_number_unsigned()) {
+    std::string iso_time = ToIso8601(it->get<uint64_t>());
+    if (!iso_time.empty()) {
+      attrs.SetAttribute(kProcessCreationTime, std::move(iso_time));
+    }
+  }
+
+  it = info.find("tags");
+  if (it != info.end() && it->is_array()) {
+    std::string tags;
+    for (const auto& tag : *it) {
+      if (!tag.is_string()) continue;
+      if (!tags.empty()) tags += ',';
+      tags += tag.get<std::string>();
+    }
+    attrs.SetAttribute("tagsString", std::move(tags));
+  }
+
+  return attrs;
+}
+
+static std::shared_ptr<Resource> MergeResourceAttributes(
+    const std::shared_ptr<Resource>& base,
+    ResourceAttributes attrs) {
+  auto resource_attributes = base->GetAttributes();
+  if (resource_attributes.find(kServiceName) != resource_attributes.end() &&
+      attrs.find(kServiceName) == attrs.end()) {
+    attrs.SetAttribute(
+        kServiceName,
+        opentelemetry::nostd::get<std::string>(
+            resource_attributes[kServiceName]));
+  }
+  auto overlay = std::make_shared<Resource>(Resource::Create(attrs));
+  return std::make_shared<Resource>(base->Merge(*overlay));
+}
+
+InstrumentationScope* GetScope() {
+  static std::unique_ptr<InstrumentationScope> scope =
+    InstrumentationScope::Create("nsolid", NODE_VERSION "+ns" NSOLID_VERSION);
+  return scope.get();
+}
+
+static void EnsureResourceInitializedLocked() {
+  if (resource_g != nullptr) return;
+
+  json config = json::parse(nsolid::GetConfig(), nullptr, false);
+  // assert because the runtime should never send me an invalid JSON config
+  ASSERT(!config.is_discarded());
+  auto it = config.find("app");
+  ASSERT(it != config.end());
+  ResourceAttributes attrs({
+    {kServiceName, it->get<std::string>()},
+    {kServiceInstanceId, nsolid::GetAgentId()}
+  });
+
+  it = config.find("appVersion");
+  if (it != config.end()) {
+    attrs.SetAttribute(kServiceVersion, it->get<std::string>());
+  }
+
+  resource_g = std::make_shared<Resource>(Resource::Create(attrs));
+}
+
+std::shared_ptr<Resource> GetResource() {
+  nsuv::ns_mutex::scoped_lock lock(ResourceMutex());
+  EnsureResourceInitializedLocked();
+  return resource_g;
+}
+
+static void EnsureMetricsResourceInitializedLocked() {
+  if (metrics_resource_g != nullptr) return;
+
+  EnsureResourceInitializedLocked();
+
+  json info = json::parse(nsolid::GetProcessInfo(), nullptr, false);
+  ResourceAttributes attrs = GetMetadataResourceAttributes(info);
+  metrics_resource_g = MergeResourceAttributes(resource_g, std::move(attrs));
+}
+
+std::shared_ptr<Resource> GetMetricsResource() {
+  nsuv::ns_mutex::scoped_lock lock(ResourceMutex());
+  EnsureMetricsResourceInitializedLocked();
+  return metrics_resource_g;
+}
+
+void InvalidateMetricsResource() {
+  nsuv::ns_mutex::scoped_lock lock(ResourceMutex());
+  metrics_resource_g.reset();
+}
+
+std::shared_ptr<Resource> UpdateResource(ResourceAttributes&& attrs) {
+  nsuv::ns_mutex::scoped_lock lock(ResourceMutex());
+  EnsureResourceInitializedLocked();
+
+  ResourceAttributes metrics_attrs(attrs);
+  resource_g = MergeResourceAttributes(resource_g, std::move(attrs));
+
+  if (metrics_resource_g != nullptr) {
+    metrics_resource_g = MergeResourceAttributes(metrics_resource_g,
+                                                std::move(metrics_attrs));
+  }
+
+  return resource_g;
+}
 
 // NOLINTNEXTLINE(runtime/references)
 static void add_counter(std::vector<MetricData>& metrics,
@@ -134,53 +379,6 @@ static void add_summary(std::vector<MetricData>& metrics,
     std::vector<PointDataAttributes>{{ attrs, summary_point_data }}
   };
   metrics.push_back(metric_data);
-}
-
-InstrumentationScope* GetScope() {
-  static std::unique_ptr<InstrumentationScope> scope =
-    InstrumentationScope::Create("nsolid", NODE_VERSION "+ns" NSOLID_VERSION);
-  return scope.get();
-}
-
-Resource* GetResource() {
-  if (!isResourceInitialized_g) {
-    json config = json::parse(nsolid::GetConfig(), nullptr, false);
-    // assert because the runtime should never send me an invalid JSON config
-    ASSERT(!config.is_discarded());
-    auto it = config.find("app");
-    ASSERT(it != config.end());
-    ResourceAttributes attrs({
-      {kServiceName, it->get<std::string>()},
-      {kServiceInstanceId, nsolid::GetAgentId()}
-    });
-
-    it = config.find("appVersion");
-    if (it != config.end()) {
-      attrs.SetAttribute(kServiceVersion, it->get<std::string>());
-    }
-
-    // Directly construct a new Resource in the unique_ptr
-    resource_g = std::make_unique<Resource>(Resource::Create(attrs));
-    isResourceInitialized_g = true;
-  }
-
-  return resource_g.get();
-}
-
-Resource* UpdateResource(ResourceAttributes&& attrs) {
-  // First, get current kServiceName to avoid overwriting it with the default
-  // value "unknown_service". (See Resource::Create() method in the SDK).
-  auto resource = GetResource();
-  auto attributes = resource->GetAttributes();
-  if (attributes.find(kServiceName) != attributes.end() &&
-      attrs.find(kServiceName) == attrs.end()) {
-    attrs.SetAttribute(kServiceName,
-        opentelemetry::nostd::get<std::string>(attributes[kServiceName]));
-  }
-
-  auto new_res = std::make_unique<Resource>(Resource::Create(attrs));
-  resource_g = std::make_unique<Resource>(resource->Merge(*new_res));
-  return resource_g.get();
 }
 
 // NOLINTNEXTLINE(runtime/references)
@@ -250,7 +448,7 @@ NSOLID_PROCESS_METRICS_DOUBLE(V)
   if (prev_stor.user != stor.user || prev_stor.title != stor.title) {
     ResourceAttributes attrs = {
       { kProcessOwner, stor.user },
-      { "process.title", stor.title },
+      { kProcessTitle, stor.title },
     };
 
     USE(UpdateResource(std::move(attrs)));
@@ -370,7 +568,8 @@ void fill_log_recordable(LogsRecordable* recordable,
     nanoseconds(static_cast<uint64_t>(info.timestamp))));
   recordable->SetTimestamp(ts);
   recordable->SetObservedTimestamp(ts);
-  recordable->SetResource(*GetResource());
+  auto resource = GetResource();
+  recordable->SetResource(*resource);
   recordable->SetInstrumentationScope(*GetScope());
 }
 
@@ -508,7 +707,8 @@ void fill_recordable(Recordable* recordable, const Tracer::SpanStor& s) {
   recordable->SetAttribute("thread.id", s.thread_id);
   recordable->SetAttribute("nsolid.span_type", s.type);
 
-  recordable->SetResource(*GetResource());
+  auto resource = GetResource();
+  recordable->SetResource(*resource);
 }
 
 }  // namespace otlp

--- a/agents/otlp/src/otlp_common.cc
+++ b/agents/otlp/src/otlp_common.cc
@@ -1,10 +1,17 @@
 #include "otlp_common.h"
 // NOLINTNEXTLINE(build/c++11)
 #include <chrono>
+#include <ctime>
+#include <iomanip>
+#include <sstream>
 #include <unordered_map>
 #include "asserts-cpp/asserts.h"
 #include "env-inl.h"
 #include "nlohmann/json.hpp"
+#include "nsuv-inl.h"
+#include "opentelemetry/semconv/incubating/deployment_attributes.h"
+#include "opentelemetry/semconv/incubating/host_attributes.h"
+#include "opentelemetry/semconv/incubating/os_attributes.h"
 #include "opentelemetry/semconv/incubating/process_attributes.h"
 #include "opentelemetry/semconv/incubating/service_attributes.h"
 #include "opentelemetry/semconv/incubating/thread_attributes.h"
@@ -44,8 +51,20 @@ using opentelemetry::trace::SpanId;
 using opentelemetry::trace::SpanKind;
 using opentelemetry::trace::TraceFlags;
 using opentelemetry::trace::TraceId;
+using opentelemetry::semconv::deployment::kDeploymentEnvironmentName;
+using opentelemetry::semconv::host::kHostArch;
+using opentelemetry::semconv::host::kHostCpuModelName;
+using opentelemetry::semconv::host::kHostName;
+using opentelemetry::semconv::os::kOsType;
 using opentelemetry::trace::propagation::detail::HexToBinary;
+using opentelemetry::semconv::process::kProcessCreationTime;
+using opentelemetry::semconv::process::kProcessExecutablePath;
 using opentelemetry::semconv::process::kProcessOwner;
+using opentelemetry::semconv::process::kProcessPid;
+using opentelemetry::semconv::process::kProcessRuntimeDescription;
+using opentelemetry::semconv::process::kProcessRuntimeName;
+using opentelemetry::semconv::process::kProcessRuntimeVersion;
+using opentelemetry::semconv::process::kProcessTitle;
 using opentelemetry::semconv::service::kServiceName;
 using opentelemetry::semconv::service::kServiceInstanceId;
 using opentelemetry::semconv::service::kServiceVersion;
@@ -67,9 +86,230 @@ static std::vector<std::string> discarded_metrics = {
   "thread_id", "timestamp"
 };
 
-static std::unique_ptr<Resource> resource_g =
-  std::make_unique<Resource>(Resource::GetEmpty());
-static bool isResourceInitialized_g = false;
+static std::shared_ptr<Resource> resource_g;
+static std::shared_ptr<Resource> metrics_resource_g;
+
+static nsuv::ns_mutex& ResourceMutex() {
+  static int er = 0;
+  static nsuv::ns_mutex mutex(&er, false);
+  ASSERT_EQ(0, er);
+  return mutex;
+}
+
+static std::string ToIso8601(uint64_t timestamp_ms) {
+  if (timestamp_ms == 0) return "";
+
+  const time_t seconds = static_cast<time_t>(timestamp_ms / 1000);
+  std::tm tm{};
+#ifdef _WIN32
+  gmtime_s(&tm, &seconds);
+#else
+  gmtime_r(&seconds, &tm);
+#endif
+
+  std::ostringstream stream;
+  stream << std::put_time(&tm, "%Y-%m-%dT%H:%M:%S");
+
+  const uint64_t millis = timestamp_ms % 1000;
+  stream << '.' << std::setw(3) << std::setfill('0') << millis;
+
+  stream << 'Z';
+  return stream.str();
+}
+
+static std::string NormalizeOsType(const std::string& platform) {
+  if (platform == "win32") return "windows";
+  if (platform == "sunos") return "solaris";
+  return platform;
+}
+
+static std::string NormalizeHostArch(const std::string& arch) {
+  if (arch == "x64") return "amd64";
+  if (arch == "ia32") return "x86";
+  if (arch == "arm") return "arm32";
+  return arch;
+}
+
+static ResourceAttributes GetMetadataResourceAttributes(const json& info) {
+  ResourceAttributes attrs;
+
+  if (info.is_discarded() || !info.is_object()) return attrs;
+
+  auto it = info.find("app");
+  if (it != info.end() && it->is_string()) {
+    attrs.SetAttribute(kServiceName, it->get<std::string>());
+  }
+
+  attrs.SetAttribute(kServiceInstanceId, nsolid::GetAgentId());
+
+  it = info.find("appVersion");
+  if (it != info.end() && it->is_string()) {
+    attrs.SetAttribute(kServiceVersion, it->get<std::string>());
+  }
+
+  it = info.find("hostname");
+  if (it != info.end() && it->is_string()) {
+    attrs.SetAttribute(kHostName, it->get<std::string>());
+  }
+
+  it = info.find("pid");
+  if (it != info.end() && it->is_number_unsigned()) {
+    attrs.SetAttribute(kProcessPid, static_cast<int64_t>(it->get<uint32_t>()));
+  }
+
+  it = info.find("arch");
+  if (it != info.end() && it->is_string()) {
+    attrs.SetAttribute(kHostArch, NormalizeHostArch(it->get<std::string>()));
+  }
+
+  it = info.find("platform");
+  if (it != info.end() && it->is_string()) {
+    attrs.SetAttribute(kOsType, NormalizeOsType(it->get<std::string>()));
+  }
+
+  it = info.find("execPath");
+  if (it != info.end() && it->is_string()) {
+    attrs.SetAttribute(kProcessExecutablePath, it->get<std::string>());
+  }
+
+  it = info.find("main");
+  if (it != info.end() && it->is_string()) {
+    attrs.SetAttribute("main", it->get<std::string>());
+  }
+
+  it = info.find("nodeEnv");
+  if (it != info.end() && it->is_string()) {
+    attrs.SetAttribute(kDeploymentEnvironmentName, it->get<std::string>());
+  }
+
+  it = info.find("versions");
+  if (it != info.end() && it->is_object()) {
+    auto version_it = it->find("node");
+    if (version_it != it->end() && version_it->is_string()) {
+      attrs.SetAttribute(kProcessRuntimeVersion,
+                         version_it->get<std::string>());
+    }
+
+    version_it = it->find("nsolid");
+    if (version_it != it->end() && version_it->is_string()) {
+      std::string nsolid_version = version_it->get<std::string>();
+      attrs.SetAttribute(kProcessRuntimeDescription,
+                         "N|Solid " + nsolid_version);
+    }
+  }
+
+  attrs.SetAttribute(kProcessRuntimeName, "nodejs");
+
+  it = info.find("cpuCores");
+  if (it != info.end() && it->is_number_unsigned()) {
+    attrs.SetAttribute("cpuCores", std::to_string(it->get<uint32_t>()));
+  }
+
+  it = info.find("cpuModel");
+  if (it != info.end() && it->is_string()) {
+    attrs.SetAttribute(kHostCpuModelName, it->get<std::string>());
+  }
+
+  it = info.find("processStart");
+  if (it != info.end() && it->is_number_unsigned()) {
+    std::string iso_time = ToIso8601(it->get<uint64_t>());
+    if (!iso_time.empty()) {
+      attrs.SetAttribute(kProcessCreationTime, std::move(iso_time));
+    }
+  }
+
+  it = info.find("tags");
+  if (it != info.end() && it->is_array()) {
+    std::string tags;
+    for (const auto& tag : *it) {
+      if (!tag.is_string()) continue;
+      if (!tags.empty()) tags += ',';
+      tags += tag.get<std::string>();
+    }
+    attrs.SetAttribute("tagsString", std::move(tags));
+  }
+
+  return attrs;
+}
+
+static std::shared_ptr<Resource> MergeResourceAttributes(
+    const std::shared_ptr<Resource>& base,
+    ResourceAttributes attrs) {
+  auto resource_attributes = base->GetAttributes();
+  if (resource_attributes.find(kServiceName) != resource_attributes.end() &&
+      attrs.find(kServiceName) == attrs.end()) {
+    attrs.SetAttribute(
+        kServiceName,
+        opentelemetry::nostd::get<std::string>(
+            resource_attributes[kServiceName]));
+  }
+  auto overlay = std::make_shared<Resource>(Resource::Create(attrs));
+  return std::make_shared<Resource>(base->Merge(*overlay));
+}
+
+InstrumentationScope* GetScope() {
+  static std::unique_ptr<InstrumentationScope> scope =
+    InstrumentationScope::Create("nsolid", NODE_VERSION "+ns" NSOLID_VERSION);
+  return scope.get();
+}
+
+static void EnsureResourceInitializedLocked() {
+  if (resource_g != nullptr) return;
+
+  json config = json::parse(nsolid::GetConfig(), nullptr, false);
+  // assert because the runtime should never send me an invalid JSON config
+  ASSERT(!config.is_discarded());
+  auto it = config.find("app");
+  ASSERT(it != config.end());
+  ResourceAttributes attrs({
+    {kServiceName, it->get<std::string>()},
+    {kServiceInstanceId, nsolid::GetAgentId()}
+  });
+
+  it = config.find("appVersion");
+  if (it != config.end()) {
+    attrs.SetAttribute(kServiceVersion, it->get<std::string>());
+  }
+
+  resource_g = std::make_shared<Resource>(Resource::Create(attrs));
+}
+
+std::shared_ptr<Resource> GetResource() {
+  nsuv::ns_mutex::scoped_lock lock(ResourceMutex());
+  EnsureResourceInitializedLocked();
+  return resource_g;
+}
+
+static void EnsureMetricsResourceInitializedLocked() {
+  if (metrics_resource_g != nullptr) return;
+
+  EnsureResourceInitializedLocked();
+
+  json info = json::parse(nsolid::GetProcessInfo(), nullptr, false);
+  ResourceAttributes attrs = GetMetadataResourceAttributes(info);
+  metrics_resource_g = MergeResourceAttributes(resource_g, std::move(attrs));
+}
+
+std::shared_ptr<Resource> GetMetricsResource() {
+  nsuv::ns_mutex::scoped_lock lock(ResourceMutex());
+  EnsureMetricsResourceInitializedLocked();
+  return metrics_resource_g;
+}
+
+std::shared_ptr<Resource> UpdateResource(ResourceAttributes&& attrs) {
+  nsuv::ns_mutex::scoped_lock lock(ResourceMutex());
+  EnsureResourceInitializedLocked();
+
+  ResourceAttributes metrics_attrs(attrs);
+  resource_g = MergeResourceAttributes(resource_g, std::move(attrs));
+
+  if (metrics_resource_g != nullptr) {
+    metrics_resource_g = MergeResourceAttributes(metrics_resource_g,
+                                                std::move(metrics_attrs));
+  }
+
+  return resource_g;
+}
 
 // NOLINTNEXTLINE(runtime/references)
 static void add_counter(std::vector<MetricData>& metrics,
@@ -134,53 +374,6 @@ static void add_summary(std::vector<MetricData>& metrics,
     std::vector<PointDataAttributes>{{ attrs, summary_point_data }}
   };
   metrics.push_back(metric_data);
-}
-
-InstrumentationScope* GetScope() {
-  static std::unique_ptr<InstrumentationScope> scope =
-    InstrumentationScope::Create("nsolid", NODE_VERSION "+ns" NSOLID_VERSION);
-  return scope.get();
-}
-
-Resource* GetResource() {
-  if (!isResourceInitialized_g) {
-    json config = json::parse(nsolid::GetConfig(), nullptr, false);
-    // assert because the runtime should never send me an invalid JSON config
-    ASSERT(!config.is_discarded());
-    auto it = config.find("app");
-    ASSERT(it != config.end());
-    ResourceAttributes attrs({
-      {kServiceName, it->get<std::string>()},
-      {kServiceInstanceId, nsolid::GetAgentId()}
-    });
-
-    it = config.find("appVersion");
-    if (it != config.end()) {
-      attrs.SetAttribute(kServiceVersion, it->get<std::string>());
-    }
-
-    // Directly construct a new Resource in the unique_ptr
-    resource_g = std::make_unique<Resource>(Resource::Create(attrs));
-    isResourceInitialized_g = true;
-  }
-
-  return resource_g.get();
-}
-
-Resource* UpdateResource(ResourceAttributes&& attrs) {
-  // First, get current kServiceName to avoid overwriting it with the default
-  // value "unknown_service". (See Resource::Create() method in the SDK).
-  auto resource = GetResource();
-  auto attributes = resource->GetAttributes();
-  if (attributes.find(kServiceName) != attributes.end() &&
-      attrs.find(kServiceName) == attrs.end()) {
-    attrs.SetAttribute(kServiceName,
-        opentelemetry::nostd::get<std::string>(attributes[kServiceName]));
-  }
-
-  auto new_res = std::make_unique<Resource>(Resource::Create(attrs));
-  resource_g = std::make_unique<Resource>(resource->Merge(*new_res));
-  return resource_g.get();
 }
 
 // NOLINTNEXTLINE(runtime/references)
@@ -250,7 +443,7 @@ NSOLID_PROCESS_METRICS_DOUBLE(V)
   if (prev_stor.user != stor.user || prev_stor.title != stor.title) {
     ResourceAttributes attrs = {
       { kProcessOwner, stor.user },
-      { "process.title", stor.title },
+      { kProcessTitle, stor.title },
     };
 
     USE(UpdateResource(std::move(attrs)));
@@ -370,7 +563,8 @@ void fill_log_recordable(LogsRecordable* recordable,
     nanoseconds(static_cast<uint64_t>(info.timestamp))));
   recordable->SetTimestamp(ts);
   recordable->SetObservedTimestamp(ts);
-  recordable->SetResource(*GetResource());
+  auto resource = GetResource();
+  recordable->SetResource(*resource);
   recordable->SetInstrumentationScope(*GetScope());
 }
 
@@ -508,7 +702,8 @@ void fill_recordable(Recordable* recordable, const Tracer::SpanStor& s) {
   recordable->SetAttribute("thread.id", s.thread_id);
   recordable->SetAttribute("nsolid.span_type", s.type);
 
-  recordable->SetResource(*GetResource());
+  auto resource = GetResource();
+  recordable->SetResource(*resource);
 }
 
 }  // namespace otlp

--- a/agents/otlp/src/otlp_common.h
+++ b/agents/otlp/src/otlp_common.h
@@ -1,6 +1,8 @@
 #ifndef AGENTS_OTLP_SRC_OTLP_COMMON_H_
 #define AGENTS_OTLP_SRC_OTLP_COMMON_H_
 
+#include <memory>
+
 #include "nsolid.h"
 #include "opentelemetry/sdk/metrics/data/metric_data.h"
 #include "opentelemetry/sdk/resource/resource.h"
@@ -42,9 +44,14 @@ namespace otlp {
 OPENTELEMETRY_NAMESPACE::sdk::instrumentationscope::InstrumentationScope*
     GetScope();
 
-OPENTELEMETRY_NAMESPACE::sdk::resource::Resource* GetResource();
+std::shared_ptr<OPENTELEMETRY_NAMESPACE::sdk::resource::Resource>
+    GetResource();
 
-OPENTELEMETRY_NAMESPACE::sdk::resource::Resource* UpdateResource(
+std::shared_ptr<OPENTELEMETRY_NAMESPACE::sdk::resource::Resource>
+    GetMetricsResource();
+
+std::shared_ptr<OPENTELEMETRY_NAMESPACE::sdk::resource::Resource>
+    UpdateResource(
     OPENTELEMETRY_NAMESPACE::sdk::resource::ResourceAttributes&&);
 
 void fill_proc_metrics(std::vector<opentelemetry::sdk::metrics::MetricData>&,

--- a/agents/otlp/src/otlp_common.h
+++ b/agents/otlp/src/otlp_common.h
@@ -1,6 +1,8 @@
 #ifndef AGENTS_OTLP_SRC_OTLP_COMMON_H_
 #define AGENTS_OTLP_SRC_OTLP_COMMON_H_
 
+#include <memory>
+
 #include "nsolid.h"
 #include "opentelemetry/sdk/metrics/data/metric_data.h"
 #include "opentelemetry/sdk/resource/resource.h"
@@ -42,9 +44,16 @@ namespace otlp {
 OPENTELEMETRY_NAMESPACE::sdk::instrumentationscope::InstrumentationScope*
     GetScope();
 
-OPENTELEMETRY_NAMESPACE::sdk::resource::Resource* GetResource();
+std::shared_ptr<OPENTELEMETRY_NAMESPACE::sdk::resource::Resource>
+    GetResource();
 
-OPENTELEMETRY_NAMESPACE::sdk::resource::Resource* UpdateResource(
+std::shared_ptr<OPENTELEMETRY_NAMESPACE::sdk::resource::Resource>
+    GetMetricsResource();
+
+void InvalidateMetricsResource();
+
+std::shared_ptr<OPENTELEMETRY_NAMESPACE::sdk::resource::Resource>
+    UpdateResource(
     OPENTELEMETRY_NAMESPACE::sdk::resource::ResourceAttributes&&);
 
 void fill_proc_metrics(std::vector<opentelemetry::sdk::metrics::MetricData>&,

--- a/agents/otlp/src/otlp_metrics.cc
+++ b/agents/otlp/src/otlp_metrics.cc
@@ -109,7 +109,8 @@ void OTLPMetrics::got_proc_metrics(const ProcessMetricsStor& stor,
   std::vector<MetricData> metrics;
   fill_proc_metrics(metrics, stor, prev_stor);
   ResourceMetrics data;
-  data.resource_ = GetResource();
+  auto resource = GetMetricsResource();
+  data.resource_ = resource.get();
   data.scope_metric_data_ = std::vector<ScopeMetrics>{{scope_, metrics}};
   auto result = otlp_metric_exporter_->Export(data);
   Debug("# ProcessMetrics Exported. Result: %d\n", static_cast<int>(result));
@@ -119,7 +120,8 @@ void OTLPMetrics::got_proc_metrics(const ProcessMetricsStor& stor,
 void OTLPMetrics::got_thr_metrics(
     const std::vector<MetricsExporter::ThrMetricsStor>& thr_metrics) {
   ResourceMetrics data;
-  data.resource_ = GetResource();
+  auto resource = GetMetricsResource();
+  data.resource_ = resource.get();
   std::vector<MetricData> metrics;
 
   for (const auto& tm : thr_metrics) {

--- a/src/nsolid/nsolid_api.cc
+++ b/src/nsolid/nsolid_api.cc
@@ -6,6 +6,7 @@
 #include "nsolid/continuous_profiler.h"
 #include "grpc/src/grpc_agent.h"
 #include "otlp/src/otlp_agent.h"
+#include "otlp/src/otlp_common.h"
 #include "statsd/src/statsd_agent.h"
 #include "util.h"
 #include "env-inl.h"
@@ -1163,10 +1164,21 @@ std::string EnvList::GetInfo() {
 }
 
 
+void EnvList::StoreInfo(const json& info) {
+  {
+    ns_mutex::scoped_lock lock(info_lock_);
+    CHECK(info.is_object());
+    info_ = info;
+  }
+
+  otlp::InvalidateMetricsResource();
+}
+
+
 void EnvList::StoreInfo(const std::string& info) {
-  ns_mutex::scoped_lock lock(info_lock_);
-  info_ = nlohmann::json::parse(info, nullptr, false);
-  CHECK(!info_.is_discarded());
+  json parsed = nlohmann::json::parse(info, nullptr, false);
+  CHECK(!parsed.is_discarded());
+  StoreInfo(parsed);
 }
 
 
@@ -1272,7 +1284,15 @@ void EnvList::UpdateConfig(const nlohmann::json& config) {
     // If tags have changed, update info_ accordingly
     it = config.find("tags");
     if (it != config.end()) {
-      info_["tags"] = *it;
+      json info;
+      {
+        ns_mutex::scoped_lock info_lock(info_lock_);
+        info = info_;
+      }
+      if (!info.is_object())
+        info = json::object();
+      info["tags"] = *it;
+      StoreInfo(info);
     }
 
     on_config_string_q_.enqueue(curr.dump());

--- a/src/nsolid/nsolid_api.h
+++ b/src/nsolid/nsolid_api.h
@@ -542,6 +542,7 @@ class EnvList {
 
   std::string GetInfo();
   void StoreInfo(const std::string& info);
+  void StoreInfo(const nlohmann::json& info);
 
   std::string CurrentConfig();
   nlohmann::json CurrentConfigJSON();

--- a/test/agents/test-grpc-metrics.mjs
+++ b/test/agents/test-grpc-metrics.mjs
@@ -210,7 +210,13 @@ function checkScopeMetrics(scopeMetrics) {
   }
 }
 
-function checkMetricsData(msg, metadata, requestId, agentId, nsolidConfig, nsolidMetrics) {
+function checkMetricsData(msg,
+                          metadata,
+                          requestId,
+                          agentId,
+                          nsolidConfig,
+                          nsolidMetrics,
+                          nsolidInfo) {
   const metrics = msg;
   assert.strictEqual(metrics.common.requestId, requestId);
   assert.strictEqual(metrics.common.command, 'metrics');
@@ -224,7 +230,11 @@ function checkMetricsData(msg, metadata, requestId, agentId, nsolidConfig, nsoli
   const resourceMetrics = metrics.body.resourceMetrics;
   validateArray(resourceMetrics, 'resourceMetrics');
   assert.strictEqual(resourceMetrics.length, 1);
-  checkResource(resourceMetrics[0].resource, agentId, nsolidConfig, nsolidMetrics);
+  checkResource(resourceMetrics[0].resource,
+                agentId,
+                nsolidConfig,
+                nsolidMetrics,
+                nsolidInfo);
   checkScopeMetrics(resourceMetrics[0].scopeMetrics);
 }
 
@@ -247,9 +257,40 @@ async function runTest({ getEnv }) {
 
       grpcServer.once('metrics', mustCall(async () => {
         const metrics = await child.metrics();
+        const info = await child.info();
         assert.strictEqual(config.app, 'my_app_name');
         const { data, requestId } = await grpcServer.metrics(agentId);
-        checkMetricsData(data.msg, data.metadata, requestId, agentId, config, metrics);
+        checkMetricsData(data.msg,
+                         data.metadata,
+                         requestId,
+                         agentId,
+                         config,
+                         metrics,
+                         info);
+
+        await child.config({ tags: ['js-api-tag'] });
+        const jsApiMetrics = await child.metrics();
+        const jsApiInfo = await child.info();
+        const jsApiData = await grpcServer.metrics(agentId);
+        checkMetricsData(jsApiData.data.msg,
+                         jsApiData.data.metadata,
+                         jsApiData.requestId,
+                         agentId,
+                         config,
+                         jsApiMetrics,
+                         jsApiInfo);
+
+        await grpcServer.reconfigure(agentId, { tags: ['reconfigured-tag'] });
+        const updatedMetrics = await child.metrics();
+        const updatedInfo = await child.info();
+        const updatedData = await grpcServer.metrics(agentId);
+        checkMetricsData(updatedData.data.msg,
+                         updatedData.data.metadata,
+                         updatedData.requestId,
+                         agentId,
+                         config,
+                         updatedMetrics,
+                         updatedInfo);
         await child.shutdown(0);
         grpcServer.close();
         resolve();

--- a/test/agents/test-grpc-metrics.mjs
+++ b/test/agents/test-grpc-metrics.mjs
@@ -209,7 +209,13 @@ function checkScopeMetrics(scopeMetrics) {
   }
 }
 
-function checkMetricsData(msg, metadata, requestId, agentId, nsolidConfig, nsolidMetrics) {
+function checkMetricsData(msg,
+                          metadata,
+                          requestId,
+                          agentId,
+                          nsolidConfig,
+                          nsolidMetrics,
+                          nsolidInfo) {
   const metrics = msg;
   assert.strictEqual(metrics.common.requestId, requestId);
   assert.strictEqual(metrics.common.command, 'metrics');
@@ -223,7 +229,11 @@ function checkMetricsData(msg, metadata, requestId, agentId, nsolidConfig, nsoli
   const resourceMetrics = metrics.body.resourceMetrics;
   validateArray(resourceMetrics, 'resourceMetrics');
   assert.strictEqual(resourceMetrics.length, 1);
-  checkResource(resourceMetrics[0].resource, agentId, nsolidConfig, nsolidMetrics);
+  checkResource(resourceMetrics[0].resource,
+                agentId,
+                nsolidConfig,
+                nsolidMetrics,
+                nsolidInfo);
   checkScopeMetrics(resourceMetrics[0].scopeMetrics);
 }
 
@@ -246,9 +256,16 @@ async function runTest({ getEnv }) {
 
       grpcServer.once('metrics', mustCall(async () => {
         const metrics = await child.metrics();
+        const info = await child.info();
         assert.strictEqual(config.app, 'my_app_name');
         const { data, requestId } = await grpcServer.metrics(agentId);
-        checkMetricsData(data.msg, data.metadata, requestId, agentId, config, metrics);
+        checkMetricsData(data.msg,
+                         data.metadata,
+                         requestId,
+                         agentId,
+                         config,
+                         metrics,
+                         info);
         await child.shutdown(0);
         grpcServer.close();
         resolve();

--- a/test/agents/test-otlp-grpc-metrics.mjs
+++ b/test/agents/test-otlp-grpc-metrics.mjs
@@ -36,6 +36,7 @@ if (process.argv[2] === 'child') {
       type: 'nsolid',
       id: nsolid.id,
       appName: nsolid.appName,
+      info: nsolid.info(),
       metrics: nsolid.metrics(),
     });
     process.on('message', mustCall((message) => {
@@ -442,25 +443,64 @@ if (process.argv[2] === 'child') {
 
   let nsolidId;
   let nsolidAppName;
+  let nsolidInfo;
   let nsolidMetrics;
+
+  function normalizeOsType(platform) {
+    if (platform === 'win32') return 'windows';
+    if (platform === 'sunos') return 'solaris';
+    return platform;
+  }
+
+  function normalizeHostArch(arch) {
+    if (arch === 'x64') return 'amd64';
+    if (arch === 'ia32') return 'x86';
+    if (arch === 'arm') return 'arm32';
+    return arch;
+  }
 
   function checkResource(resource) {
     validateArray(resource.attributes, 'attributes');
 
     const expectedAttributes = {
-      'telemetry.sdk.version': process.versions.opentelemetry,
-      'telemetry.sdk.language': 'cpp',
-      'telemetry.sdk.name': 'opentelemetry',
-      'service.instance.id': nsolidId,
-      'service.name': nsolidAppName,
-      'process.title': nsolidMetrics.title,
-      'process.owner': nsolidMetrics.user,
+      'telemetry.sdk.version': { type: 'stringValue', value: process.versions.opentelemetry },
+      'telemetry.sdk.language': { type: 'stringValue', value: 'cpp' },
+      'telemetry.sdk.name': { type: 'stringValue', value: 'opentelemetry' },
+      'service.instance.id': { type: 'stringValue', value: nsolidId },
+      'service.name': { type: 'stringValue', value: nsolidAppName },
+      'host.name': { type: 'stringValue', value: nsolidInfo.hostname },
+      'process.pid': { type: 'intValue', value: `${nsolidInfo.pid}` },
+      'host.arch': { type: 'stringValue', value: normalizeHostArch(nsolidInfo.arch) },
+      'os.type': { type: 'stringValue', value: normalizeOsType(nsolidInfo.platform) },
+      'process.executable.path': { type: 'stringValue', value: nsolidInfo.execPath },
+      'main': { type: 'stringValue', value: nsolidInfo.main },
+      'deployment.environment.name': { type: 'stringValue', value: nsolidInfo.nodeEnv },
+      'process.runtime.version': { type: 'stringValue', value: nsolidInfo.versions.node },
+      'process.runtime.description': {
+        type: 'stringValue',
+        value: `N|Solid ${nsolidInfo.versions.nsolid}`,
+      },
+      'process.runtime.name': { type: 'stringValue', value: 'nodejs' },
+      'cpuCores': { type: 'intValue', value: `${nsolidInfo.cpuCores}` },
+      'host.cpu.model.name': { type: 'stringValue', value: nsolidInfo.cpuModel },
+      'process.creation.time': {
+        type: 'stringValue',
+        value: new Date(nsolidInfo.processStart).toISOString(),
+      },
+      'tagsString': {
+        type: 'stringValue',
+        value: Array.isArray(nsolidInfo.tags) ? nsolidInfo.tags.join(',') : '',
+      },
+      'process.title': { type: 'stringValue', value: nsolidMetrics.title },
+      'process.owner': { type: 'stringValue', value: nsolidMetrics.user },
     };
 
     assert.strictEqual(resource.attributes.length, Object.keys(expectedAttributes).length);
 
     resource.attributes.forEach(mustCall((attribute) => {
-      assert.strictEqual(attribute.value.stringValue, expectedAttributes[attribute.key]);
+      const expected = expectedAttributes[attribute.key];
+      assert.notStrictEqual(expected, undefined, `Unexpected resource attribute: ${attribute.key}`);
+      assert.strictEqual(attribute.value[expected.type], expected.value);
       delete expectedAttributes[attribute.key];
     }, resource.attributes.length));
 
@@ -631,6 +671,7 @@ if (process.argv[2] === 'child') {
           if (message.type === 'nsolid') {
             nsolidId = message.id;
             nsolidAppName = message.appName;
+            nsolidInfo = message.info;
             nsolidMetrics = message.metrics;
           } else if (message.type === 'workerThreadId') {
             context.threadList.push(message.id);

--- a/test/agents/test-otlp-grpc-metrics.mjs
+++ b/test/agents/test-otlp-grpc-metrics.mjs
@@ -36,6 +36,7 @@ if (process.argv[2] === 'child') {
       type: 'nsolid',
       id: nsolid.id,
       appName: nsolid.appName,
+      info: nsolid.info(),
       metrics: nsolid.metrics(),
     });
     process.on('message', mustCall((message) => {
@@ -441,25 +442,64 @@ if (process.argv[2] === 'child') {
 
   let nsolidId;
   let nsolidAppName;
+  let nsolidInfo;
   let nsolidMetrics;
+
+  function normalizeOsType(platform) {
+    if (platform === 'win32') return 'windows';
+    if (platform === 'sunos') return 'solaris';
+    return platform;
+  }
+
+  function normalizeHostArch(arch) {
+    if (arch === 'x64') return 'amd64';
+    if (arch === 'ia32') return 'x86';
+    if (arch === 'arm') return 'arm32';
+    return arch;
+  }
 
   function checkResource(resource) {
     validateArray(resource.attributes, 'attributes');
 
     const expectedAttributes = {
-      'telemetry.sdk.version': process.versions.opentelemetry,
-      'telemetry.sdk.language': 'cpp',
-      'telemetry.sdk.name': 'opentelemetry',
-      'service.instance.id': nsolidId,
-      'service.name': nsolidAppName,
-      'process.title': nsolidMetrics.title,
-      'process.owner': nsolidMetrics.user,
+      'telemetry.sdk.version': { type: 'stringValue', value: process.versions.opentelemetry },
+      'telemetry.sdk.language': { type: 'stringValue', value: 'cpp' },
+      'telemetry.sdk.name': { type: 'stringValue', value: 'opentelemetry' },
+      'service.instance.id': { type: 'stringValue', value: nsolidId },
+      'service.name': { type: 'stringValue', value: nsolidAppName },
+      'host.name': { type: 'stringValue', value: nsolidInfo.hostname },
+      'process.pid': { type: 'intValue', value: `${nsolidInfo.pid}` },
+      'host.arch': { type: 'stringValue', value: normalizeHostArch(nsolidInfo.arch) },
+      'os.type': { type: 'stringValue', value: normalizeOsType(nsolidInfo.platform) },
+      'process.executable.path': { type: 'stringValue', value: nsolidInfo.execPath },
+      'main': { type: 'stringValue', value: nsolidInfo.main },
+      'deployment.environment.name': { type: 'stringValue', value: nsolidInfo.nodeEnv },
+      'process.runtime.version': { type: 'stringValue', value: nsolidInfo.versions.node },
+      'process.runtime.description': {
+        type: 'stringValue',
+        value: `N|Solid ${nsolidInfo.versions.nsolid}`,
+      },
+      'process.runtime.name': { type: 'stringValue', value: 'nodejs' },
+      'cpuCores': { type: 'stringValue', value: `${nsolidInfo.cpuCores}` },
+      'host.cpu.model.name': { type: 'stringValue', value: nsolidInfo.cpuModel },
+      'process.creation.time': {
+        type: 'stringValue',
+        value: new Date(nsolidInfo.processStart).toISOString(),
+      },
+      'tagsString': {
+        type: 'stringValue',
+        value: Array.isArray(nsolidInfo.tags) ? nsolidInfo.tags.join(',') : '',
+      },
+      'process.title': { type: 'stringValue', value: nsolidMetrics.title },
+      'process.owner': { type: 'stringValue', value: nsolidMetrics.user },
     };
 
     assert.strictEqual(resource.attributes.length, Object.keys(expectedAttributes).length);
 
     resource.attributes.forEach(mustCall((attribute) => {
-      assert.strictEqual(attribute.value.stringValue, expectedAttributes[attribute.key]);
+      const expected = expectedAttributes[attribute.key];
+      assert.notStrictEqual(expected, undefined, `Unexpected resource attribute: ${attribute.key}`);
+      assert.strictEqual(attribute.value[expected.type], expected.value);
       delete expectedAttributes[attribute.key];
     }, resource.attributes.length));
 
@@ -630,6 +670,7 @@ if (process.argv[2] === 'child') {
           if (message.type === 'nsolid') {
             nsolidId = message.id;
             nsolidAppName = message.appName;
+            nsolidInfo = message.info;
             nsolidMetrics = message.metrics;
           } else if (message.type === 'workerThreadId') {
             context.threadList.push(message.id);

--- a/test/agents/test-otlp-metrics.mjs
+++ b/test/agents/test-otlp-metrics.mjs
@@ -38,6 +38,7 @@ if (process.argv[2] === 'child') {
       type: 'nsolid',
       id: nsolid.id,
       appName: nsolid.appName,
+      info: nsolid.info(),
       metrics: nsolid.metrics(),
     });
     process.on('message', mustCall((message) => {
@@ -444,25 +445,64 @@ if (process.argv[2] === 'child') {
 
   let nsolidId;
   let nsolidAppName;
+  let nsolidInfo;
   let nsolidMetrics;
+
+  function normalizeOsType(platform) {
+    if (platform === 'win32') return 'windows';
+    if (platform === 'sunos') return 'solaris';
+    return platform;
+  }
+
+  function normalizeHostArch(arch) {
+    if (arch === 'x64') return 'amd64';
+    if (arch === 'ia32') return 'x86';
+    if (arch === 'arm') return 'arm32';
+    return arch;
+  }
 
   function checkResource(resource) {
     validateArray(resource.attributes, 'attributes');
 
     const expectedAttributes = {
-      'telemetry.sdk.version': process.versions.opentelemetry,
-      'telemetry.sdk.language': 'cpp',
-      'telemetry.sdk.name': 'opentelemetry',
-      'service.instance.id': nsolidId,
-      'service.name': nsolidAppName,
-      'process.title': nsolidMetrics.title,
-      'process.owner': nsolidMetrics.user,
+      'telemetry.sdk.version': { type: 'stringValue', value: process.versions.opentelemetry },
+      'telemetry.sdk.language': { type: 'stringValue', value: 'cpp' },
+      'telemetry.sdk.name': { type: 'stringValue', value: 'opentelemetry' },
+      'service.instance.id': { type: 'stringValue', value: nsolidId },
+      'service.name': { type: 'stringValue', value: nsolidAppName },
+      'host.name': { type: 'stringValue', value: nsolidInfo.hostname },
+      'process.pid': { type: 'intValue', value: `${nsolidInfo.pid}` },
+      'host.arch': { type: 'stringValue', value: normalizeHostArch(nsolidInfo.arch) },
+      'os.type': { type: 'stringValue', value: normalizeOsType(nsolidInfo.platform) },
+      'process.executable.path': { type: 'stringValue', value: nsolidInfo.execPath },
+      'main': { type: 'stringValue', value: nsolidInfo.main },
+      'deployment.environment.name': { type: 'stringValue', value: nsolidInfo.nodeEnv },
+      'process.runtime.version': { type: 'stringValue', value: nsolidInfo.versions.node },
+      'process.runtime.description': {
+        type: 'stringValue',
+        value: `N|Solid ${nsolidInfo.versions.nsolid}`,
+      },
+      'process.runtime.name': { type: 'stringValue', value: 'nodejs' },
+      'cpuCores': { type: 'intValue', value: `${nsolidInfo.cpuCores}` },
+      'host.cpu.model.name': { type: 'stringValue', value: nsolidInfo.cpuModel },
+      'process.creation.time': {
+        type: 'stringValue',
+        value: new Date(nsolidInfo.processStart).toISOString(),
+      },
+      'tagsString': {
+        type: 'stringValue',
+        value: Array.isArray(nsolidInfo.tags) ? nsolidInfo.tags.join(',') : '',
+      },
+      'process.title': { type: 'stringValue', value: nsolidMetrics.title },
+      'process.owner': { type: 'stringValue', value: nsolidMetrics.user },
     };
 
     assert.strictEqual(resource.attributes.length, Object.keys(expectedAttributes).length);
 
     resource.attributes.forEach(mustCall((attribute) => {
-      assert.strictEqual(attribute.value.stringValue, expectedAttributes[attribute.key]);
+      const expected = expectedAttributes[attribute.key];
+      assert.notStrictEqual(expected, undefined, `Unexpected resource attribute: ${attribute.key}`);
+      assert.strictEqual(attribute.value[expected.type], expected.value);
       delete expectedAttributes[attribute.key];
     }, resource.attributes.length));
 
@@ -604,6 +644,7 @@ if (process.argv[2] === 'child') {
           if (message.type === 'nsolid') {
             nsolidId = message.id;
             nsolidAppName = message.appName;
+            nsolidInfo = message.info;
             assert.strictEqual(nsolidAppName, appName);
             nsolidMetrics = message.metrics;
           } else if (message.type === 'workerThreadId') {

--- a/test/agents/test-otlp-metrics.mjs
+++ b/test/agents/test-otlp-metrics.mjs
@@ -38,6 +38,7 @@ if (process.argv[2] === 'child') {
       type: 'nsolid',
       id: nsolid.id,
       appName: nsolid.appName,
+      info: nsolid.info(),
       metrics: nsolid.metrics(),
     });
     process.on('message', mustCall((message) => {
@@ -443,25 +444,64 @@ if (process.argv[2] === 'child') {
 
   let nsolidId;
   let nsolidAppName;
+  let nsolidInfo;
   let nsolidMetrics;
+
+  function normalizeOsType(platform) {
+    if (platform === 'win32') return 'windows';
+    if (platform === 'sunos') return 'solaris';
+    return platform;
+  }
+
+  function normalizeHostArch(arch) {
+    if (arch === 'x64') return 'amd64';
+    if (arch === 'ia32') return 'x86';
+    if (arch === 'arm') return 'arm32';
+    return arch;
+  }
 
   function checkResource(resource) {
     validateArray(resource.attributes, 'attributes');
 
     const expectedAttributes = {
-      'telemetry.sdk.version': process.versions.opentelemetry,
-      'telemetry.sdk.language': 'cpp',
-      'telemetry.sdk.name': 'opentelemetry',
-      'service.instance.id': nsolidId,
-      'service.name': nsolidAppName,
-      'process.title': nsolidMetrics.title,
-      'process.owner': nsolidMetrics.user,
+      'telemetry.sdk.version': { type: 'stringValue', value: process.versions.opentelemetry },
+      'telemetry.sdk.language': { type: 'stringValue', value: 'cpp' },
+      'telemetry.sdk.name': { type: 'stringValue', value: 'opentelemetry' },
+      'service.instance.id': { type: 'stringValue', value: nsolidId },
+      'service.name': { type: 'stringValue', value: nsolidAppName },
+      'host.name': { type: 'stringValue', value: nsolidInfo.hostname },
+      'process.pid': { type: 'intValue', value: `${nsolidInfo.pid}` },
+      'host.arch': { type: 'stringValue', value: normalizeHostArch(nsolidInfo.arch) },
+      'os.type': { type: 'stringValue', value: normalizeOsType(nsolidInfo.platform) },
+      'process.executable.path': { type: 'stringValue', value: nsolidInfo.execPath },
+      'main': { type: 'stringValue', value: nsolidInfo.main },
+      'deployment.environment.name': { type: 'stringValue', value: nsolidInfo.nodeEnv },
+      'process.runtime.version': { type: 'stringValue', value: nsolidInfo.versions.node },
+      'process.runtime.description': {
+        type: 'stringValue',
+        value: `N|Solid ${nsolidInfo.versions.nsolid}`,
+      },
+      'process.runtime.name': { type: 'stringValue', value: 'nodejs' },
+      'cpuCores': { type: 'stringValue', value: `${nsolidInfo.cpuCores}` },
+      'host.cpu.model.name': { type: 'stringValue', value: nsolidInfo.cpuModel },
+      'process.creation.time': {
+        type: 'stringValue',
+        value: new Date(nsolidInfo.processStart).toISOString(),
+      },
+      'tagsString': {
+        type: 'stringValue',
+        value: Array.isArray(nsolidInfo.tags) ? nsolidInfo.tags.join(',') : '',
+      },
+      'process.title': { type: 'stringValue', value: nsolidMetrics.title },
+      'process.owner': { type: 'stringValue', value: nsolidMetrics.user },
     };
 
     assert.strictEqual(resource.attributes.length, Object.keys(expectedAttributes).length);
 
     resource.attributes.forEach(mustCall((attribute) => {
-      assert.strictEqual(attribute.value.stringValue, expectedAttributes[attribute.key]);
+      const expected = expectedAttributes[attribute.key];
+      assert.notStrictEqual(expected, undefined, `Unexpected resource attribute: ${attribute.key}`);
+      assert.strictEqual(attribute.value[expected.type], expected.value);
       delete expectedAttributes[attribute.key];
     }, resource.attributes.length));
 
@@ -603,6 +643,7 @@ if (process.argv[2] === 'child') {
           if (message.type === 'nsolid') {
             nsolidId = message.id;
             nsolidAppName = message.appName;
+            nsolidInfo = message.info;
             assert.strictEqual(nsolidAppName, appName);
             nsolidMetrics = message.metrics;
           } else if (message.type === 'workerThreadId') {

--- a/test/common/nsolid-grpc-agent/client.js
+++ b/test/common/nsolid-grpc-agent/client.js
@@ -171,6 +171,8 @@ if (isMainThread) {
       nsolid.heapSampling(msg.duration);
     } else if (msg.type === 'id') {
       process.send({ type: 'id', id: nsolid.id });
+    } else if (msg.type === 'info') {
+      process.send({ type: 'info', info: nsolid.info() });
     } else if (msg.type === 'import') {
       console.log(msg);
       if (threadId === msg.threadId) {

--- a/test/common/nsolid-grpc-agent/client.js
+++ b/test/common/nsolid-grpc-agent/client.js
@@ -170,6 +170,8 @@ if (isMainThread) {
       nsolid.heapSampling(msg.duration);
     } else if (msg.type === 'id') {
       process.send({ type: 'id', id: nsolid.id });
+    } else if (msg.type === 'info') {
+      process.send({ type: 'info', info: nsolid.info() });
     } else if (msg.type === 'import') {
       console.log(msg);
       if (threadId === msg.threadId) {

--- a/test/common/nsolid-grpc-agent/index.js
+++ b/test/common/nsolid-grpc-agent/index.js
@@ -46,7 +46,7 @@ function checkExitData(data, metadata, agentId, expectedData) {
   checkRpcMetadata(metadata, agentId);
 }
 
-function checkResource(resource, agentId, config, metrics) {
+function checkResource(resource, agentId, config, metrics, info) {
   validateArray(resource.attributes, 'attributes');
 
   const expectedAttributes = {
@@ -63,10 +63,46 @@ function checkResource(resource, agentId, config, metrics) {
     expectedAttributes['process.owner'] = metrics.user;
   }
 
+  if (info) {
+    const normalizeOsType = (platform) => {
+      if (platform === 'win32') return 'windows';
+      if (platform === 'sunos') return 'solaris';
+      return platform;
+    };
+
+    const normalizeHostArch = (arch) => {
+      if (arch === 'x64') return 'amd64';
+      if (arch === 'ia32') return 'x86';
+      if (arch === 'arm') return 'arm32';
+      return arch;
+    };
+
+    expectedAttributes['host.name'] = info.hostname;
+    expectedAttributes['process.pid'] = `${info.pid}`;
+    expectedAttributes['host.arch'] = normalizeHostArch(info.arch);
+    expectedAttributes['os.type'] = normalizeOsType(info.platform);
+    expectedAttributes['process.executable.path'] = info.execPath;
+    expectedAttributes.main = info.main;
+    expectedAttributes['deployment.environment.name'] = info.nodeEnv;
+    expectedAttributes['process.runtime.version'] = info.versions.node;
+    expectedAttributes['process.runtime.description'] = `N|Solid ${info.versions.nsolid}`;
+    expectedAttributes['process.runtime.name'] = 'nodejs';
+    expectedAttributes['host.cpu.model.name'] = info.cpuModel;
+    expectedAttributes['process.creation.time'] =
+      new Date(info.processStart).toISOString();
+    expectedAttributes.cpuCores = `${info.cpuCores}`;
+    expectedAttributes.tagsString = Array.isArray(info.tags) ?
+      info.tags.join(',') :
+      '';
+  }
+
   assert.strictEqual(resource.attributes.length, Object.keys(expectedAttributes).length);
 
   resource.attributes.forEach((attribute) => {
-    assert.strictEqual(attribute.value.stringValue, expectedAttributes[attribute.key]);
+    const expected = expectedAttributes[attribute.key];
+    assert.notStrictEqual(expected, undefined, `Unexpected resource attribute: ${attribute.key}`);
+    const actual = attribute.value.stringValue ?? attribute.value.intValue;
+    assert.strictEqual(actual, expected);
     delete expectedAttributes[attribute.key];
   });
 
@@ -468,6 +504,16 @@ class TestClient {
       } else {
         resolve(null);
       }
+    });
+  }
+
+  async info() {
+    if (!this.#child)
+      return null;
+    return this.#sendAndWait({
+      type: 'info',
+      expect: 'info',
+      map: (msg) => msg?.info ?? null,
     });
   }
 

--- a/test/common/nsolid-grpc-agent/index.js
+++ b/test/common/nsolid-grpc-agent/index.js
@@ -40,7 +40,7 @@ function checkExitData(data, metadata, agentId, expectedData) {
   assert.strictEqual(metadata['nsolid-agent-id'][0], agentId);
 }
 
-function checkResource(resource, agentId, config, metrics) {
+function checkResource(resource, agentId, config, metrics, info) {
   validateArray(resource.attributes, 'attributes');
 
   const expectedAttributes = {
@@ -57,10 +57,46 @@ function checkResource(resource, agentId, config, metrics) {
     expectedAttributes['process.owner'] = metrics.user;
   }
 
+  if (info) {
+    const normalizeOsType = (platform) => {
+      if (platform === 'win32') return 'windows';
+      if (platform === 'sunos') return 'solaris';
+      return platform;
+    };
+
+    const normalizeHostArch = (arch) => {
+      if (arch === 'x64') return 'amd64';
+      if (arch === 'ia32') return 'x86';
+      if (arch === 'arm') return 'arm32';
+      return arch;
+    };
+
+    expectedAttributes['host.name'] = info.hostname;
+    expectedAttributes['process.pid'] = `${info.pid}`;
+    expectedAttributes['host.arch'] = normalizeHostArch(info.arch);
+    expectedAttributes['os.type'] = normalizeOsType(info.platform);
+    expectedAttributes['process.executable.path'] = info.execPath;
+    expectedAttributes.main = info.main;
+    expectedAttributes['deployment.environment.name'] = info.nodeEnv;
+    expectedAttributes['process.runtime.version'] = info.versions.node;
+    expectedAttributes['process.runtime.description'] = `N|Solid ${info.versions.nsolid}`;
+    expectedAttributes['process.runtime.name'] = 'nodejs';
+    expectedAttributes['host.cpu.model.name'] = info.cpuModel;
+    expectedAttributes['process.creation.time'] =
+      new Date(info.processStart).toISOString();
+    expectedAttributes.cpuCores = `${info.cpuCores}`;
+    expectedAttributes.tagsString = Array.isArray(info.tags) ?
+      info.tags.join(',') :
+      '';
+  }
+
   assert.strictEqual(resource.attributes.length, Object.keys(expectedAttributes).length);
 
   resource.attributes.forEach((attribute) => {
-    assert.strictEqual(attribute.value.stringValue, expectedAttributes[attribute.key]);
+    const expected = expectedAttributes[attribute.key];
+    assert.notStrictEqual(expected, undefined, `Unexpected resource attribute: ${attribute.key}`);
+    const actual = attribute.value.stringValue ?? attribute.value.intValue;
+    assert.strictEqual(actual, expected);
     delete expectedAttributes[attribute.key];
   });
 
@@ -463,6 +499,16 @@ class TestClient {
       } else {
         resolve(null);
       }
+    });
+  }
+
+  async info() {
+    if (!this.#child)
+      return null;
+    return this.#sendAndWait({
+      type: 'info',
+      expect: 'info',
+      map: (msg) => msg?.info ?? null,
     });
   }
 


### PR DESCRIPTION
Add process metadata from nsolid.info() to OTLP metric resources while leaving logs and traces on the common resource. Metrics now include different attributes derived from process `info`. This will ease our internal metrics handling.

Keep resource access thread-safe by returning shared resource snapshots guarded by nsuv::ns_mutex. This avoids use-after-free if UpdateResource() replaces a resource while another thread is exporting telemetry.

Update gRPC and OTLP metrics tests to validate the expanded resource attributes.

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Metrics now include a dedicated metrics resource and richer telemetry metadata (host, OS/arch, process, runtime, CPU, service and deployment details).
  * Tests and agent messaging now exchange runtime info for richer validation.

* **Bug Fixes**
  * Safer, concurrency-aware resource management and more robust resource updates; process metadata preserves service name and uses the correct process title key.

* **Tests**
  * Expanded, stricter tests: typed resource attributes are validated comprehensively and unexpected keys are rejected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->