### PR TITLE
deps: bump ncm-ng to 2.9.8

### DIFF
--- a/deps/ncm-ng/package.json
+++ b/deps/ncm-ng/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ns-private/ncm-ng",
-  "version": "2.9.7",
+  "version": "2.9.8",
   "main": "index.js",
   "publishConfig": {
     "registry": "http://packages-internal.nodesource.io"
@@ -37,8 +37,8 @@
     "spdx-satisfies": "^5.0.1",
     "ssri": "^8.0.1",
     "stats-lite": "^2.2.0",
-    "tar": "^6.0.1",
+    "tar": "^7.5.13",
     "tmp": "^0.2.1",
-    "uuid": "^8.3.0"
+    "uuid": "^14.0.0"
   }
 }


### PR DESCRIPTION
Bumps `deps/ncm-ng` version `2.9.7` → `2.9.8`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Bumped ncm-ng package version to 2.9.8 (was 2.9.7).
  * Updated dependencies: tar -> ^7.5.13 and uuid -> ^14.0.0.
  * Minor, low-risk release with no other functional or manifest changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->