### PR TITLE
src: avoid accessing EnvInst on Env destruction

### DIFF
--- a/src/nsolid/nsolid_api.cc
+++ b/src/nsolid/nsolid_api.cc
@@ -1420,12 +1420,16 @@ void EnvList::PromiseTracking(bool promiseTracking) {
   }
 
   for (auto& entry : env_map) {
-    EnvInst* envinst = entry.second.get();
-    if (envinst->env()->nsolid_track_promises_fn().IsEmpty())
+    SharedEnvInst envinst_sp = entry.second;
+    EnvInst::Scope lock(envinst_sp);
+    if (!lock.Success())
+      continue;
+
+    if (envinst_sp->env()->nsolid_track_promises_fn().IsEmpty())
       continue;
 
     int er = EnvInst::RunCommand(
-      EnvInst::GetInst(envinst->thread_id()),
+      envinst_sp,
       promiseTracking ? enable_promise_tracking_ : disable_promise_tracking_,
       nullptr,
       CommandType::InterruptOnly);
@@ -1457,8 +1461,12 @@ void EnvList::UpdateTracingFlags(uint32_t flags) {
   }
 
   for (auto& entry : env_map) {
-    SharedEnvInst envinst = entry.second;
-    int er = RunCommand(envinst,
+    SharedEnvInst envinst_sp = entry.second;
+    EnvInst::Scope lock(envinst_sp);
+    if (!lock.Success())
+      continue;
+
+    int er = RunCommand(envinst_sp,
                         CommandType::InterruptOnly,
                         update_tracing_flags,
                         flags);
@@ -2141,8 +2149,12 @@ void EnvList::UpdateHasMetricsStreamHooks(bool has_metrics) {
   }
 
   for (auto& entry : env_map) {
-    SharedEnvInst envinst = entry.second;
-    int er = RunCommand(envinst,
+    SharedEnvInst envinst_sp = entry.second;
+    EnvInst::Scope lock(envinst_sp);
+    if (!lock.Success())
+      continue;
+
+    int er = RunCommand(envinst_sp,
                         CommandType::InterruptOnly,
                         update_has_metrics_stream_hooks,
                         has_metrics);

--- a/src/nsolid/nsolid_api.h
+++ b/src/nsolid/nsolid_api.h
@@ -952,7 +952,7 @@ inline std::pair<uint64_t, uint64_t> EnvInst::provider_times() {
   // Need to lock this so the event loop isn't erased while attempting to read
   // the provider time.
   EnvInst::Scope scp(this);
-  if (event_loop_ == nullptr)
+  if (!scp.Success() || event_loop_ == nullptr)
     return { 0, 0 };
   uv_metrics_provider_times(event_loop_, &entry, &exit);
   return { entry, exit };


### PR DESCRIPTION
I was seeing random crashes when running `test/parallel/test-cli-node-options.js`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced internal locking mechanisms for environment management to improve stability and robustness of runtime operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->