### PR TITLE
agents: add nsolidVersion attr to metrics

### DIFF
--- a/agents/otlp/src/otlp_common.cc
+++ b/agents/otlp/src/otlp_common.cc
@@ -193,8 +193,7 @@ static ResourceAttributes GetMetadataResourceAttributes(const json& info) {
     version_it = it->find("nsolid");
     if (version_it != it->end() && version_it->is_string()) {
       std::string nsolid_version = version_it->get<std::string>();
-      attrs.SetAttribute(kProcessRuntimeDescription,
-                         "N|Solid " + nsolid_version);
+      attrs.SetAttribute("nsolidVersion", std::move(nsolid_version));
     }
   }
 

--- a/test/agents/test-otlp-grpc-metrics.mjs
+++ b/test/agents/test-otlp-grpc-metrics.mjs
@@ -476,9 +476,9 @@ if (process.argv[2] === 'child') {
       'main': { type: 'stringValue', value: nsolidInfo.main },
       'deployment.environment.name': { type: 'stringValue', value: nsolidInfo.nodeEnv },
       'process.runtime.version': { type: 'stringValue', value: nsolidInfo.versions.node },
-      'process.runtime.description': {
+      'nsolidVersion': {
         type: 'stringValue',
-        value: `N|Solid ${nsolidInfo.versions.nsolid}`,
+        value: nsolidInfo.versions.nsolid,
       },
       'process.runtime.name': { type: 'stringValue', value: 'nodejs' },
       'cpuCores': { type: 'intValue', value: `${nsolidInfo.cpuCores}` },

--- a/test/agents/test-otlp-metrics.mjs
+++ b/test/agents/test-otlp-metrics.mjs
@@ -478,9 +478,9 @@ if (process.argv[2] === 'child') {
       'main': { type: 'stringValue', value: nsolidInfo.main },
       'deployment.environment.name': { type: 'stringValue', value: nsolidInfo.nodeEnv },
       'process.runtime.version': { type: 'stringValue', value: nsolidInfo.versions.node },
-      'process.runtime.description': {
+      'nsolidVersion': {
         type: 'stringValue',
-        value: `N|Solid ${nsolidInfo.versions.nsolid}`,
+        value: nsolidInfo.versions.nsolid,
       },
       'process.runtime.name': { type: 'stringValue', value: 'nodejs' },
       'cpuCores': { type: 'intValue', value: `${nsolidInfo.cpuCores}` },

--- a/test/common/nsolid-grpc-agent/index.js
+++ b/test/common/nsolid-grpc-agent/index.js
@@ -85,7 +85,7 @@ function checkResource(resource, agentId, config, metrics, info) {
     expectedAttributes.main = info.main;
     expectedAttributes['deployment.environment.name'] = info.nodeEnv;
     expectedAttributes['process.runtime.version'] = info.versions.node;
-    expectedAttributes['process.runtime.description'] = `N|Solid ${info.versions.nsolid}`;
+    expectedAttributes.nsolidVersion = info.versions.nsolid;
     expectedAttributes['process.runtime.name'] = 'nodejs';
     expectedAttributes['host.cpu.model.name'] = info.cpuModel;
     expectedAttributes['process.creation.time'] =


### PR DESCRIPTION
Instead of using kProcessRuntimeDescription.

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * N|Solid version is no longer embedded in the runtime description; it’s exposed as a dedicated telemetry resource attribute for clearer, more consistent metadata.

* **Tests**
  * Updated telemetry tests to expect the new dedicated version attribute and remove the prior expectation that the runtime description contained the N|Solid version string.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->