### PR TITLE
grpc: fix statsdTags in reconfigure response

### DIFF
--- a/agents/grpc/src/grpc_agent.cc
+++ b/agents/grpc/src/grpc_agent.cc
@@ -388,7 +388,7 @@ void PopulateReconfigureEvent(grpcagent::ReconfigureEvent* reconfigure_event,
   if (it != config.end()) {
     body->set_statsdbucket(it->get<std::string>());
   }
-  it = config.find("statsdtags");
+  it = config.find("statsdTags");
   if (it != config.end()) {
     body->set_statsdtags(it->get<std::string>());
   }

--- a/test/agents/test-grpc-reconfigure.mjs
+++ b/test/agents/test-grpc-reconfigure.mjs
@@ -32,12 +32,28 @@ function checkReconfigureData(reconfigure, metadata, requestId, agentId, nsolidC
   // Normalize the configuration objects for comparison
   const normalizedReconfigBody = {};
   const normalizedNsolidConfig = {};
+  const configKeys = [
+    'blockedLoopThreshold',
+    'interval',
+    'pauseMetrics',
+    'promiseTracking',
+    'redactSnapshots',
+    'statsd',
+    'statsdBucket',
+    'statsdTags',
+    'tags',
+    'tracingEnabled',
+    'tracingModulesBlacklist',
+    'contCpuProfile',
+    'assetsEnabled',
+    'traceSampleRate',
+  ];
 
   // Process reconfigure.body - remove properties starting with underscore
   for (const [key, value] of Object.entries(reconfigure.body)) {
     if (!key.startsWith('_')) {
-      // Convert string numbers to actual numbers for comparison
-      if (typeof value === 'string' && !Number.isNaN(Number(value))) {
+      const expectedValue = nsolidConfig[key];
+      if (typeof expectedValue === 'number' && typeof value === 'string') {
         normalizedReconfigBody[key] = Number(value);
       } else {
         normalizedReconfigBody[key] = value;
@@ -45,8 +61,9 @@ function checkReconfigureData(reconfigure, metadata, requestId, agentId, nsolidC
     }
   }
 
-  // Process nsolidConfig - include only keys that exist in normalizedReconfigBody
-  for (const key of Object.keys(normalizedReconfigBody)) {
+  // Compare against the expected reconfigure keys, not only the keys already
+  // present in the response, so missing fields fail the test.
+  for (const key of configKeys) {
     if (key in nsolidConfig) {
       normalizedNsolidConfig[key] = nsolidConfig[key];
     }
@@ -148,7 +165,19 @@ tests.push({
           checkReconfigureData(data.msg, data.metadata, requestId, agentId, nsolidConfig);
 
           // Verify that the specific field has been updated correctly
-          console.log(`Checking if ${key} was updated to ${val}`);
+          console.log('Checking if ' + key + ' was updated to ' + val);
+
+          const bodyVal = data.msg.body[key];
+          const normalizedBodyVal =
+            typeof val === 'number' && typeof bodyVal === 'string' ?
+              Number(bodyVal) :
+              bodyVal;
+
+          assert.deepStrictEqual(
+            normalizedBodyVal,
+            val,
+            'Expected reconfigure body ' + key + ' to be ' + val + ', but got ' + bodyVal,
+          );
 
           // Compare the values
           assert.deepStrictEqual(


### PR DESCRIPTION
The gRPC reconfigure response dropped `statsdTags` because `PopulateReconfigureEvent()` looked up the wrong config key.

Harden the gRPC reconfigure test to assert response fields directly and to fail when expected config keys are missing from the response body.`

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed StatsD tag updates during gRPC reconfiguration by correctly reading the `statsdTags` value from the configuration.

* **Tests**
  * Strengthened gRPC reconfigure response validation to require all expected configuration fields.
  * Improved comparison logic for numeric-like values to ensure consistent, predictable assertions across response types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->