### PR TITLE
build: add split-debug release and package targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,9 @@ GCOV ?= gcov
 PWD = $(CURDIR)
 BUILD_WITH ?= make
 FIND ?= find
+OBJCOPY ?= objcopy
+STRIP ?= strip
+SEPARATE_DEBUG_SYMBOLS ?= 0
 
 ifdef JOBS
 	PARALLEL_ARGS = -j $(JOBS)
@@ -87,11 +90,26 @@ NODE ?= $(PWD)/$(NODE_EXE)
 # when generating coverage reports or running toolings as
 # debug build is be slower.
 OUT_NODE ?= $(PWD)/out/$(BUILDTYPE)/node$(EXEEXT)
+RELEASE_NODE ?= $(PWD)/out/Release/$(NODE_EXE)
+RELEASE_DEBUG_SYMBOLS ?= $(RELEASE_NODE).debug
+BINARY_DEBUG_SYMBOLS ?= $(BINARYNAME).debug
+
+define split_debug_symbols
+	$(OBJCOPY) --only-keep-debug $(1) $(2)
+	$(STRIP) --strip-debug --strip-unneeded $(1)
+endef
+
+define add_debuglink
+	$(OBJCOPY) --add-gnu-debuglink=$(2) $(1)
+endef
 
 # Flags for packaging.
 BUILD_DOWNLOAD_FLAGS ?= --download=all
 BUILD_INTL_FLAGS ?= --with-intl=full-icu
 BUILD_RELEASE_FLAGS ?= $(BUILD_DOWNLOAD_FLAGS) $(BUILD_INTL_FLAGS)
+ifeq ($(SEPARATE_DEBUG_SYMBOLS),1)
+BUILD_RELEASE_FLAGS += --debug-symbols
+endif
 
 # Default to quiet/pretty builds.
 # To do verbose builds, run `make V=1` or set the V environment variable.
@@ -629,6 +647,14 @@ test-ci: | clear-stalled bench-addons-build build-addons build-js-native-api-tes
 build-ci: ## Build everything (CI).
 	$(PYTHON) ./configure --verbose $(CONFIG_FLAGS)
 	$(MAKE)
+
+.PHONY: release-debug-artifacts
+release-debug-artifacts: ## Build Release with -g, save debug symbols, and strip the shipped binary.
+	$(PYTHON) ./configure --verbose $(CONFIG_FLAGS) --debug-symbols
+	$(RM) -r out/Release
+	$(MAKE) $(NODE_EXE)
+	$(call split_debug_symbols,$(RELEASE_NODE),$(RELEASE_DEBUG_SYMBOLS))
+	$(call add_debuglink,$(RELEASE_NODE),$(RELEASE_DEBUG_SYMBOLS))
 
 .PHONY: run-ci
 # Run by CI tests, exceptions:
@@ -1325,6 +1351,10 @@ $(BINARYTAR): release-only
 		--release-urlbase=$(RELEASE_URLBASE) \
 		$(CONFIG_FLAGS) $(BUILD_RELEASE_FLAGS)
 	$(MAKE) install DESTDIR=$(BINARYNAME) V=$(V) PORTABLE=1
+ifeq ($(SEPARATE_DEBUG_SYMBOLS),1)
+	$(call split_debug_symbols,$(BINARYNAME)/bin/$(NODE_EXE),$(BINARY_DEBUG_SYMBOLS))
+	$(call add_debuglink,$(BINARYNAME)/bin/$(NODE_EXE),$(BINARY_DEBUG_SYMBOLS))
+endif
 	cp README.md $(BINARYNAME)
 	cp LICENSE $(BINARYNAME)
 	cp LICENSE_NSOLID $(BINARYNAME)


### PR DESCRIPTION
Add Makefile support for generating separate debug symbol artifacts
from release builds while keeping distributed binaries stripped.

`make release-debug-artifacts` builds `out/Release/nsolid`,
writes `out/Release/nsolid.debug`, strips the release binary,
and adds a debug link back to it.

`make binary SEPARATE_DEBUG_SYMBOLS=1` passes `--debug-symbols`
to `./configure`, strips the packaged `bin/nsolid`, and writes a
separate `$(BINARYNAME).debug` artifact for upload to debuginfod.

`make binary` keeps the previous behavior and does not generate a
separate debug symbol artifact.


<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a configurable Release setting to generate separate debug-symbol artifacts and link them back to the shipped binaries.
  * Release builds now support emitting debug symbols alongside the main release output when enabled.
* **Chores**
  * Introduced a dedicated Release workflow that rebuilds the Release binary and automatically splits debug symbols into companion files.
  * Updated Release binary tarball packaging to include the separated debug-symbol outputs when the setting is enabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->